### PR TITLE
Pull new changes and re-apply previous changes

### DIFF
--- a/open_samus_returns_rando/files/custom_scenario.lua
+++ b/open_samus_returns_rando/files/custom_scenario.lua
@@ -5,7 +5,46 @@ setmetatable(Scenario, {__index = _G})
 setfenv(1, Scenario)
 
 function HideLoadingScreen()
-	Game.SetLoadingScreen(false)
-	loadingscreen.HideLoadingScreen()
-	Game.HUDIdleScreenLeave()
+ Game.SetLoadingScreen(false)
+ loadingscreen.HideLoadingScreen()
+ Game.HUDIdleScreenLeave()
+ if table.getn(CurrentScenario.tHazarous) > 0 then
+  for key, value in pairs(CurrentScenario.tHazarous) do
+   EnableHazarous(key, false)
+  end
+ end
+end
+
+function EnableHazarous(_ARG_0_, _ARG_1_)
+ if CurrentScenario.EnableHazarous ~= nil then
+  CurrentScenario.EnableHazarous(_ARG_0_, _ARG_1_)
+ end
+ if CurrentScenario.OnHazarousPoolDrain ~= nil then
+  CurrentScenario.OnHazarousPoolDrain("")
+ end
+ if CurrentScenario.tHazarous[_ARG_0_] ~= nil then
+  for _FORV_6_, _FORV_7_ in pairs(CurrentScenario.tHazarous[_ARG_0_].Triggers) do
+   if CanaManageHazarousEntity(_ARG_0_, "Triggers", _FORV_7_, _ARG_1_) and Game.GetEntity(_FORV_7_) ~= nil then
+    if _ARG_1_ then
+     Game.GetEntity(_FORV_7_):Disable()
+    else
+     Game.GetEntity(_FORV_7_):Enable()
+    end
+   end
+   end
+   for _FORV_6_, _FORV_7_ in pairs(CurrentScenario.tHazarous[_ARG_0_].SpawnGroups) do
+    if CanaManageHazarousEntity(_ARG_0_, "SpawnGroups", _FORV_7_, _ARG_1_) and Game.GetEntity(_FORV_7_) ~= nil then
+     if _ARG_1_ then
+      Game.GetEntity(_FORV_7_).SPAWNGROUP:DisableSpawnGroup()
+     else
+      Game.GetEntity(_FORV_7_).SPAWNGROUP:EnableSpawnGroup()
+     end
+   end
+  end
+  for _FORV_6_, _FORV_7_ in pairs(CurrentScenario.tHazarous[_ARG_0_].Usables) do
+   if CanaManageHazarousEntity(_ARG_0_, "Usables", _FORV_7_, _ARG_1_) and Game.GetEntity(_FORV_7_) ~= nil then
+    Game.GetEntity(_FORV_7_).USABLE:Activate(not _ARG_1_)
+   end
+  end
+ end
 end

--- a/open_samus_returns_rando/files/levels/s000_surface.lc.lua
+++ b/open_samus_returns_rando/files/levels/s000_surface.lc.lua
@@ -94,6 +94,7 @@ function s000_surface.InitFromBlackboard()
     Game.SetPlayerInputEnabled(false, false)
     s000_surface.LaunchPlanetArrival()
   end
+  Game.GetEntity("LE_HazarousPool").HAZAROUSPOOL:Activate(false)
 end
 function s000_surface.OnReloaded()
 end


### PR DESCRIPTION
Auto-drain surface hazardous pool.
Auto-enable all hazardous pool spawngroups, usables, and triggers.