### PR TITLE
Hazardous pools and metroid intro fights.

### DIFF
--- a/open_samus_returns_rando/files/custom_scenario.lua
+++ b/open_samus_returns_rando/files/custom_scenario.lua
@@ -5,7 +5,46 @@ setmetatable(Scenario, {__index = _G})
 setfenv(1, Scenario)
 
 function HideLoadingScreen()
-	Game.SetLoadingScreen(false)
-	loadingscreen.HideLoadingScreen()
-	Game.HUDIdleScreenLeave()
+ Game.SetLoadingScreen(false)
+ loadingscreen.HideLoadingScreen()
+ Game.HUDIdleScreenLeave()
+ if table.getn(CurrentScenario.tHazarous) > 0 then
+  for key, value in pairs(CurrentScenario.tHazarous) do
+   EnableHazarous(key, false)
+  end
+ end
+end
+
+function EnableHazarous(_ARG_0_, _ARG_1_)
+ if CurrentScenario.EnableHazarous ~= nil then
+  CurrentScenario.EnableHazarous(_ARG_0_, _ARG_1_)
+ end
+ if CurrentScenario.OnHazarousPoolDrain ~= nil then
+  CurrentScenario.OnHazarousPoolDrain("")
+ end
+ if CurrentScenario.tHazarous[_ARG_0_] ~= nil then
+  for _FORV_6_, _FORV_7_ in pairs(CurrentScenario.tHazarous[_ARG_0_].Triggers) do
+   if CanaManageHazarousEntity(_ARG_0_, "Triggers", _FORV_7_, _ARG_1_) and Game.GetEntity(_FORV_7_) ~= nil then
+    if _ARG_1_ then
+     Game.GetEntity(_FORV_7_):Disable()
+    else
+     Game.GetEntity(_FORV_7_):Enable()
+    end
+   end
+   end
+   for _FORV_6_, _FORV_7_ in pairs(CurrentScenario.tHazarous[_ARG_0_].SpawnGroups) do
+    if CanaManageHazarousEntity(_ARG_0_, "SpawnGroups", _FORV_7_, _ARG_1_) and Game.GetEntity(_FORV_7_) ~= nil then
+     if _ARG_1_ then
+      Game.GetEntity(_FORV_7_).SPAWNGROUP:DisableSpawnGroup()
+     else
+      Game.GetEntity(_FORV_7_).SPAWNGROUP:EnableSpawnGroup()
+     end
+   end
+  end
+  for _FORV_6_, _FORV_7_ in pairs(CurrentScenario.tHazarous[_ARG_0_].Usables) do
+   if CanaManageHazarousEntity(_ARG_0_, "Usables", _FORV_7_, _ARG_1_) and Game.GetEntity(_FORV_7_) ~= nil then
+    Game.GetEntity(_FORV_7_).USABLE:Activate(not _ARG_1_)
+   end
+  end
+ end
 end

--- a/open_samus_returns_rando/files/levels/s000_surface.lc.lua
+++ b/open_samus_returns_rando/files/levels/s000_surface.lc.lua
@@ -69,7 +69,7 @@ function s000_surface.OnShipStartPointTeleport(_ARG_0_, _ARG_1_)
   end
 end
 function s000_surface.InitFromBlackboard()
-  
+  Scenario.WriteToBlackboard("LarvaPresentationPlayed", "b", true)
   if Scenario.ReadFromBlackboard("LarvaPresentationPlayed", false) then
     Game.DisableTrigger("TG_Intro_MetroidSurface")
   else
@@ -194,13 +194,15 @@ function s000_surface.LaunchFirstTimeAlphaPresentation()
   --Game.SetPlayerInputEnabled(false, false)
 end
 function s000_surface.OnAlphaPresentationCutsceneLaunch()
-  Game.MetroidRadarForceStateOnBegin(2, -1, true, true)
-  Game.SetSceneGroupEnabledByName("sg_BrokenEggCinematic", false)
-  if Game.GetEntity("SG_Alpha_001") ~= nil then
-    Game.GetEntity("SG_Alpha_001").SPAWNGROUP:EnableSpawnGroup()
-    if Game.GetEntityFromSpawnPoint("SP_Alpha_001") ~= nil then
-      Game.GetEntityFromSpawnPoint("SP_Alpha_001").AI:SetBossCamera(true)
-      Game.StopEntitySound(Game.GetEntityFromSpawnPoint("SP_Alpha_001").sName, "actors/alpha/alpha_loop.wav", 0)
+  if not Scenario.ReadFromBlackboard("alpha_dead",false) then
+    Game.MetroidRadarForceStateOnBegin(2, -1, true, true)
+    Game.SetSceneGroupEnabledByName("sg_BrokenEggCinematic", false)
+    if Game.GetEntity("SG_Alpha_001") ~= nil then
+      Game.GetEntity("SG_Alpha_001").SPAWNGROUP:EnableSpawnGroup()
+      if Game.GetEntityFromSpawnPoint("SP_Alpha_001") ~= nil then
+        --Game.GetEntityFromSpawnPoint("SP_Alpha_001").AI:SetBossCamera(true)
+        Game.StopEntitySound(Game.GetEntityFromSpawnPoint("SP_Alpha_001").sName, "actors/alpha/alpha_loop.wav", 0)
+      end
     end
   end
 end
@@ -455,7 +457,10 @@ function s000_surface.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4
     GUI.EndMeleeReminderTutorial()
     Game.DelSF("s000_surface.ScheduledStartMeleeReminderTutorial")
     Game.DelSF("GUI.StartMeleeReminderTutorial")
+  elseif _ARG_0_ == "collision_camera_024" then
+    s000_surface.LaunchFirstTimeAlphaPresentation()  
   end
+  
   --if _ARG_0_ == "collision_camera_002" and _ARG_2_ == "collision_camera_003" and not Scenario.ReadFromBlackboard("FirstTimeChozoStatuePlayed", false) then
   --  s000_surface.LaunchFirstTimeChozoStatuePresentation()
   --elseif _ARG_0_ == "collision_camera_016" and _ARG_2_ == "collision_camera_002" and not Scenario.ReadFromBlackboard("MeleeTutoPlayed", false) then
@@ -516,6 +521,7 @@ function s000_surface.LaunchMeleeTutoCutscene()
 end
 function s000_surface.OnDnaAbsorbAnimation()
   Game.SetInGameMusicState("DEATH")
+  Scenario.WriteToBlackboard("alpha_killed", "b", true)
 end
 function s000_surface.OnMeleeTutoButtonPressed()
   Game.ChangeCutscene("cutscenes/meleetuto/takes/03/meleetuto03.bmscu")

--- a/open_samus_returns_rando/files/levels/s000_surface.lc.lua
+++ b/open_samus_returns_rando/files/levels/s000_surface.lc.lua
@@ -94,6 +94,7 @@ function s000_surface.InitFromBlackboard()
     Game.SetPlayerInputEnabled(false, false)
     s000_surface.LaunchPlanetArrival()
   end
+  Game.GetEntity("LE_HazarousPool").HAZAROUSPOOL:Activate(false)
 end
 function s000_surface.OnReloaded()
 end

--- a/open_samus_returns_rando/files/levels/s010_area1.lc.lua
+++ b/open_samus_returns_rando/files/levels/s010_area1.lc.lua
@@ -45,6 +45,7 @@ function s010_area1.InitFromBlackboard()
   end
   Game.SetCollisionCameraTransitionOverride("collision_camera_008", "collision_camera_037", 2.5, 0.1)
   Game.SetCollisionCameraTransitionOverride("collision_camera_030", "collision_camera_038", 2.5, 0.1)
+  Game.GetEntity("LE_HazarousPool").HAZAROUSPOOL:Activate(false)
 end
 function s010_area1.OnReloaded()
 end

--- a/open_samus_returns_rando/files/levels/s025_area2b.lc.lua
+++ b/open_samus_returns_rando/files/levels/s025_area2b.lc.lua
@@ -82,7 +82,7 @@ function s025_area2b.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_
   if _ARG_3_ ~= "PostVariaSuit" then
     Game.SetSubAreaEnvironmentLocked(false, false, false)
   end
-  if _ARG_0_ == "collision_camera012" and _ARG_2_ == "collision_camera037" and not Scenario.ReadFromBlackboard("GammaIntroCutscenePlayed", false) then
+  if (_ARG_0_ == "collision_camera012" or _ARG_0_ == "collision_camera011") and _ARG_2_ == "collision_camera037" and not Scenario.ReadFromBlackboard("GammaIntroCutscenePlayed", false) then
     s025_area2b.LaunchFirstTimeGammaPresentation()
   end
 end

--- a/open_samus_returns_rando/files/levels/s028_area2c.lc.lua
+++ b/open_samus_returns_rando/files/levels/s028_area2c.lc.lua
@@ -81,6 +81,7 @@ function s028_area2c.ElevatorSetTarget(_ARG_0_)
   end
 end
 function s028_area2c.InitFromBlackboard()
+  Game.GetEntity("LE_HazarousPool").HAZAROUSPOOL:Activate(false)
 end
 function s028_area2c.OnReloaded()
 end

--- a/open_samus_returns_rando/files/levels/s030_area3.lc.lua
+++ b/open_samus_returns_rando/files/levels/s030_area3.lc.lua
@@ -235,6 +235,7 @@ function s030_area3.InitFromBlackboard()
   if Game.GetEntity("LE_Event_03") ~= nil and Scenario.ReadFromBlackboard("SpecialEvent03Launched") then
     Game.GetEntity("LE_Event_03"):Disable()
   end
+  Game.GetEntity("LE_HazarousPool").HAZAROUSPOOL:Activate(false)
 end
 function s030_area3.LaunchSpecialEnergyCutscene()
   Game.LaunchCutscene("cutscenes/energywave/takes/01/energywave01.bmscu")

--- a/open_samus_returns_rando/files/levels/s040_area4.lc.lua
+++ b/open_samus_returns_rando/files/levels/s040_area4.lc.lua
@@ -339,16 +339,16 @@ function s040_area4.InitFromBlackboard()
   Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_001", true)
   Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_002", true)
   if Blackboard.GetProp("s040_area4", "entity_LE_HazarousPool_001_enabled") == nil then
-    Game.GetEntity("LE_HazarousPool_001").HAZAROUSPOOL:Activate(true)
-    Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_001", false)
+    Game.GetEntity("LE_HazarousPool_001").HAZAROUSPOOL:Activate(false)
+    Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_001", true)
     Game.GetEntity("LE_HazarousPool_002").HAZAROUSPOOL:Activate(false)
-    Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_002", false)
+    Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_002", true)
   elseif Blackboard.GetProp("s040_area4", "entity_LE_HazarousPool_002_enabled") == nil then
-    Game.GetEntity("LE_HazarousPool_002").HAZAROUSPOOL:Activate(true)
-    Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_002", false)
+    Game.GetEntity("LE_HazarousPool_002").HAZAROUSPOOL:Activate(false)
+    Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_002", true)
   else
-    Game.GetEntity("LE_HazarousPool_001").HAZAROUSPOOL:Activate((Blackboard.GetProp("s040_area4", "entity_LE_HazarousPool_001_enabled")))
-    Game.GetEntity("LE_HazarousPool_002").HAZAROUSPOOL:Activate((Blackboard.GetProp("s040_area4", "entity_LE_HazarousPool_002_enabled")))
+    --Game.GetEntity("LE_HazarousPool_001").HAZAROUSPOOL:Activate((Blackboard.GetProp("s040_area4", "entity_LE_HazarousPool_001_enabled")))
+    --Game.GetEntity("LE_HazarousPool_002").HAZAROUSPOOL:Activate((Blackboard.GetProp("s040_area4", "entity_LE_HazarousPool_002_enabled")))
   end
   s040_area4.OnFansInit()
   Game.SetArenaDefaultSpawnGroup("Gamma_001", "SG_Gamma_001_A")
@@ -367,19 +367,25 @@ function s040_area4.OnEnter_ActivationTeleport_04_01()
   Game.OnTeleportApproached("LE_Teleporter_04_01")
 end
 function s040_area4.OnHazarousPoolDrain(_ARG_0_)
-  if _ARG_0_ == "LE_HazarousPool_001" then
-    Game.SetSubAreaCurrentSetup("collision_camera_006", "Hazarous_empty_001", true)
-    Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_001", true)
-  elseif _ARG_0_ == "LE_HazarousPool_002" then
-    Game.SetSubAreaCurrentSetup("collision_camera_006", "Hazarous_empty_002", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_022", "Hazarous_empty_002", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_023", "Hazarous_empty_002", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_010", "Hazarous_empty_002", true)
-    Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_002", true)
-  end
-  if _ARG_0_ == "LE_HazarousPool_001" then
-    Game.GetEntity("LE_HazarousPool_002").HAZAROUSPOOL:Activate(true)
-  end
+  --if _ARG_0_ == "LE_HazarousPool_001" then
+  --  Game.SetSubAreaCurrentSetup("collision_camera_006", "Hazarous_empty_001", true)
+  --  Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_001", true)
+  --elseif _ARG_0_ == "LE_HazarousPool_002" then
+   -- Game.SetSubAreaCurrentSetup("collision_camera_006", "Hazarous_empty_002", true)
+   -- Game.SetSubAreaCurrentSetup("collision_camera_022", "Hazarous_empty_002", true)
+   -- Game.SetSubAreaCurrentSetup("collision_camera_023", "Hazarous_empty_002", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_010", "Hazarous_empty_002", true)
+  --  Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_002", true)
+ -- end
+  --if _ARG_0_ == "LE_HazarousPool_001" then
+  --  Game.GetEntity("LE_HazarousPool_002").HAZAROUSPOOL:Activate(true)
+  --end
+  -- Set all camera's
+  Game.SetSubAreaCurrentSetup("collision_camera_006", "Hazarous_empty_001", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_006", "Hazarous_empty_002", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_022", "Hazarous_empty_002", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_023", "Hazarous_empty_002", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_010", "Hazarous_empty_002", true)
 end
 function s040_area4.OnEnterHazardous_001()
   PoisonZone.OnEnter()

--- a/open_samus_returns_rando/files/levels/s060_area6.lc.lua
+++ b/open_samus_returns_rando/files/levels/s060_area6.lc.lua
@@ -93,6 +93,7 @@ function s060_area6.SetupDebugGameBlackboard()
   Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_SPECIAL_ENERGY_PHASE_DISPLACEMENT", "f", 0)
 end
 function s060_area6.InitFromBlackboard()
+  Game.GetEntity("LE_HazarousPool").HAZAROUSPOOL:Activate(false)
 end
 function s060_area6.OnReloaded()
 end

--- a/open_samus_returns_rando/files/levels/s070_area7.lc.lua
+++ b/open_samus_returns_rando/files/levels/s070_area7.lc.lua
@@ -91,7 +91,7 @@ s070_area7.tDNAScanLandmarks = {
 }
 function s070_area7.InitFromBlackboard()
   if Blackboard.GetProp("s070_area7", "entity_LE_HazarousPool_001_enabled") == nil then
-    Game.GetEntity("LE_HazarousPool_001").HAZAROUSPOOL:Activate(true)
+    Game.GetEntity("LE_HazarousPool_001").HAZAROUSPOOL:Activate(false)
     Game.GetEntity("LE_HazarousPool_002").HAZAROUSPOOL:Activate(false)
   end
   s070_area7.OnFansInit()
@@ -118,27 +118,39 @@ function s070_area7.OnEnter_ActivationTeleport_07_02()
   Game.OnTeleportApproached("LE_Teleporter_07_02")
 end
 function s070_area7.OnHazarousPoolDrain(_ARG_0_)
-  if _ARG_0_ == "LE_HazarousPool_001" then
-    Game.SetSubAreaCurrentSetup("collision_camera_037", "Omega_Enabled", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_Hazard_End_A", "Hazardous_Phase_02", true)
-    Scenario.WriteToBlackboard("OmegaDiscovered", "b", true)
-    Game.SetSceneGroupEnabledByName("sg_SubArea_ValveOmega", false)
-    Game.SetSubAreaCurrentSetup("collision_camera_051", "Hazardous_Phase_02", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_060", "Hazardous_Phase_02", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_042", "Hazardous_Phase_02", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_Hazard_End_B", "Hazardous_Phase_02", true)
-  elseif _ARG_0_ == "LE_HazarousPool_002" then
-    Game.SetSubAreaCurrentSetup("collision_camera_Hazard_End_A", "Hazardous_Phase_03", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_051", "Hazardous_Phase_03", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_060", "Hazardous_Phase_03", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_Hazard_End_B", "Hazardous_Phase_03", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_034", "Hazardous_Phase_03", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_035", "Hazardous_Phase_03", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_043", "Hazardous_Phase_03", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_045", "Hazardous_Phase_03", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_044", "Hazardous_Phase_03", true)
-    Game.SetSubAreaCurrentSetup("collision_camera_042", "Hazardous_Phase_03", true)
-  end
+  --if _ARG_0_ == "LE_HazarousPool_001" then
+  --  Game.SetSubAreaCurrentSetup("collision_camera_037", "Omega_Enabled", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_Hazard_End_A", "Hazardous_Phase_02", true)
+  --  Scenario.WriteToBlackboard("OmegaDiscovered", "b", true)
+  --  Game.SetSceneGroupEnabledByName("sg_SubArea_ValveOmega", false)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_051", "Hazardous_Phase_02", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_060", "Hazardous_Phase_02", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_042", "Hazardous_Phase_02", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_Hazard_End_B", "Hazardous_Phase_02", true)
+  --elseif _ARG_0_ == "LE_HazarousPool_002" then
+  --  Game.SetSubAreaCurrentSetup("collision_camera_Hazard_End_A", "Hazardous_Phase_03", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_051", "Hazardous_Phase_03", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_060", "Hazardous_Phase_03", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_Hazard_End_B", "Hazardous_Phase_03", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_034", "Hazardous_Phase_03", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_035", "Hazardous_Phase_03", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_043", "Hazardous_Phase_03", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_045", "Hazardous_Phase_03", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_044", "Hazardous_Phase_03", true)
+  --  Game.SetSubAreaCurrentSetup("collision_camera_042", "Hazardous_Phase_03", true)
+  --end
+  Game.SetSubAreaCurrentSetup("collision_camera_037", "Omega_Enabled", true)
+  Scenario.WriteToBlackboard("OmegaDiscovered", "b", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_Hazard_End_A", "Hazardous_Phase_03", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_051", "Hazardous_Phase_03", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_060", "Hazardous_Phase_03", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_Hazard_End_B", "Hazardous_Phase_03", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_034", "Hazardous_Phase_03", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_035", "Hazardous_Phase_03", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_043", "Hazardous_Phase_03", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_045", "Hazardous_Phase_03", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_044", "Hazardous_Phase_03", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_042", "Hazardous_Phase_03", true)
 end
 function s070_area7.OnEnterHazardous_001()
   PoisonZone.OnEnter()
@@ -791,7 +803,7 @@ function s070_area7.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_)
       Game.SetCameraEnemy("manicminerbot")
       s070_area7.LaunchManicMinerBotIntroCutscene()
     end
-  elseif _ARG_0_ == "collision_camera_047" and _ARG_2_ == "collision_camera_037" and _ARG_3_ == "Omega_Enabled" and not Scenario.ReadFromBlackboard("OmegaIntroCutscenePlayed", false) then
+  elseif (_ARG_0_ == "collision_camera_047" or _ARG_2_ == "collision_camera_046") and (_ARG_2_ == "collision_camera_037" or _ARG_2_ == "collision_camera_046") and _ARG_3_ == "Omega_Enabled" and not Scenario.ReadFromBlackboard("OmegaIntroCutscenePlayed", false) then
     s070_area7.LaunchFirstTimeOmegaPresentation()
   end
   if _ARG_2_ == "collision_camera_037" and _ARG_3_ == "Omega_Enabled" and not Scenario.ReadFromBlackboard("entity_SG_Omega_001_deaths", false) then

--- a/open_samus_returns_rando/files/levels/s090_area9.lc.lua
+++ b/open_samus_returns_rando/files/levels/s090_area9.lc.lua
@@ -115,6 +115,7 @@ function s090_area9.InitFromBlackboard()
   s090_area9.bAfterOmegasKilledMusicChange = false
   s090_area9.AllOmegasDeadCallback()
   s090_area9.OnFansInit()
+  Game.GetEntity("LE_HazarousPool").HAZAROUSPOOL:Activate(false)
 end
 function s090_area9.OnReloaded()
 end


### PR DESCRIPTION
Enable the metroid intro fights even if you enter from the wrong door.
Auto-drain all other Hazardous pools and enable correct cameras.