### PR TITLE
Fix collecting Gravity Suit in liquids not removing effects

### DIFF
--- a/open_samus_returns_rando/files/randomizer_powerup.lua
+++ b/open_samus_returns_rando/files/randomizer_powerup.lua
@@ -41,7 +41,23 @@ function RandomizerPowerup.OnPickedUp(actor, resources)
     return granted
 end
 
+function RandomizerPowerup.DisableLiquids()
+    if Game.GetPlayer().MODELUPDATER.sModelAlias == "Varia" then
+        if Scenario.CurrentScenarioID == "s010_area1" then
+            Game.GetEntity("Lava_Trigger_001").TRIGGER:DisableTrigger()
+        elseif Scenario.CurrentScenarioID == "s067_area6c" then
+            Game.GetEntity("TG_SP_Water_002").TRIGGER:DisableTrigger()
+        end
+    end
+end
 
+function RandomizerPowerup.EnableLiquids()
+    if Scenario.CurrentScenarioID == "s010_area1" then
+        Game.GetEntity("Lava_Trigger_001").TRIGGER:EnableTrigger()
+    elseif Scenario.CurrentScenarioID == "s067_area6c" then
+        Game.GetEntity("TG_SP_Water_002").TRIGGER:EnableTrigger()
+    end
+end
 
 function RandomizerPowerup.HandlePickupResources(progression)
     progression = progression or {}
@@ -71,7 +87,9 @@ function RandomizerPowerup.HandlePickupResources(progression)
 
             if shouldGrant then
                 for _, resource in ipairs(resource_list) do
+                    RandomizerPowerup.DisableLiquids()
                     RandomizerPowerup.IncreaseItemAmount(resource.item_id, resource.quantity)
+                    RandomizerPowerup.EnableLiquids()
                 end
 
                 return resource_list
@@ -137,7 +155,8 @@ end
 RandomizerGravitySuit = {}
 setmetatable(RandomizerGravitySuit, {__index = RandomizerPowerup})
 function RandomizerGravitySuit.OnPickedUp(actor, progression)
+    RandomizerPowerup.DisableLiquids()
     RandomizerPowerup.OnPickedUp(actor, progression)
     Game.GetEntity("Samus").MODELUPDATER.sModelAlias = "Gravity"
-    Game.GetPlayer():StopEntityLoopWithFade("actors/samus/damage_alarm.wav", 0.6)
+    RandomizerPowerup.EnableLiquids()
 end

--- a/open_samus_returns_rando/pickup.py
+++ b/open_samus_returns_rando/pickup.py
@@ -86,7 +86,7 @@ class ActorPickup(BasePickup):
 
     def patch(self, editor: PatcherEditor):
         template_bmsad = editor.get_parsed_asset(
-            "actors/items/powerup_chargebeam/charclasses/powerup_chargebeam.bmsad"
+            "actors/items/powerup_spiderball/charclasses/powerup_spiderball.bmsad"
             ).raw
 
         actor_reference = self.pickup["pickup_actor"]


### PR DESCRIPTION
fixes #62

Also now uses Spider Ball as the template bmsad so breakable blocks don't get deleted. Related to #8 