### PR TITLE
Remove PB weakness from Beam Doors

### DIFF
--- a/open_samus_returns_rando/files/schema.json
+++ b/open_samus_returns_rando/files/schema.json
@@ -114,6 +114,17 @@
             "default": false,
             "description": "When true, the game will start with the whole map revealed"
         },
+        "game_patches": {
+            "type": "object",
+            "properties": {
+                "nerf_power_bombs": {
+                    "type": "boolean",
+                    "description": "Changes weaknesses for certain props to make Power Bombs less overpowered.",
+                    "default": false
+                }
+            },
+            "additionalProperties": false
+        },
         "new_spawn_points": {
             "type": "array",
             "description": "Creates new spawn points",

--- a/open_samus_returns_rando/samus_returns_patcher.py
+++ b/open_samus_returns_rando/samus_returns_patcher.py
@@ -11,6 +11,7 @@ from open_samus_returns_rando.misc_patches import lua_util
 from open_samus_returns_rando.misc_patches.exefs import DSPatch
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 from open_samus_returns_rando.pickup import patch_pickups
+from open_samus_returns_rando.specific_patches import game_patches
 from open_samus_returns_rando.validator_with_default import DefaultValidatingDraft7Validator
 
 T = typing.TypeVar("T")
@@ -118,6 +119,9 @@ def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
 
     # custom spawn points
     patch_spawn_points(editor, configuration["new_spawn_points"])
+
+    # Specific game patches
+    game_patches.apply_game_patches(editor, configuration.get("game_patches", {}))
 
     # Create Exefs patches (currently there are none)
     LOG.info("Creating exefs patches")

--- a/open_samus_returns_rando/specific_patches/game_patches.py
+++ b/open_samus_returns_rando/specific_patches/game_patches.py
@@ -1,0 +1,31 @@
+from mercury_engine_data_structures.formats import Bmsad
+
+from open_samus_returns_rando.patcher_editor import PatcherEditor
+
+def apply_game_patches(editor: PatcherEditor, configuration: dict):
+
+    if configuration["nerf_power_bombs"]:
+        _remove_pb_weaknesses(editor)
+
+def _remove_pb_weaknesses(editor: PatcherEditor):
+    # Charge Door
+    for door in ["doorchargecharge", "doorclosedcharge"]:
+        charge_door = editor.get_file(f"actors/props/{door}/charclasses/{door}.bmsad", Bmsad)
+        func = charge_door.raw.components.LIFE.functions[0]
+        if func.params.Param1.value:
+            func.params.Param1.value = "CHARGE_BEAM"
+        if func.params.Param2.value:
+            func.params.Param2.value = "CHARGE_BEAM"
+
+    # Beam Doors
+    for door in ["doorwave", "doorspazerbeam", "doorcreature"]:
+        beam_door = editor.get_file(f"actors/props/{door}/charclasses/{door}.bmsad", Bmsad)
+        func_wp = beam_door.raw.components.LIFE.functions[1]
+        func_s = beam_door.raw.components.LIFE.functions[2]
+        if func_wp.params.Param1.value:
+            if door == "doorwave":
+                func_wp.params.Param1.value = "WAVE_BEAM"
+            else:
+                func_wp.params.Param1.value = "PLASMA_BEAM"
+        if func_s.params.Param1.value:
+            func_s.params.Param1.value = "SPAZER_BEAM"

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -80,5 +80,8 @@
         ],
         "energy_per_tank": 100,
         "aeion_per_tank": 50,
-        "reveal_map_on_start": true
+        "reveal_map_on_start": true,
+        "game_patches": {
+          "nerf_power_bombs": true
+        }
       }


### PR DESCRIPTION
Beam Doors, including Charge, now need there respective beam to open. Charge Doors can still be opened by Beam Burst.

Related #42