### PR TITLE
Support Shuffled Baby

### DIFF
--- a/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -347,6 +347,7 @@ function s100_area10.OnQueenGenerated(_ARG_0_, _ARG_1_)
   end
 end
 function s100_area10.OnQueenDead(_ARG_0_)
+  Scenario.WriteToBlackboard("firstTimeMetroidHatchlingIntroPlayed", "b", true)
   Blackboard.SetProp("DEFEATED_ENEMIES", "Queen", "i", 1)
   Game.SetSubAreaCurrentSetup("collision_camera_020", "PostMetroids_001", true)
   Game.LaunchCutscene("cutscenes/metroidqueendeath/takes/01/metroidqueendeath01.bmscu")
@@ -375,29 +376,30 @@ function s100_area10.OnEndQueenDeathCutscene()
   Game.SaveGame("checkpoint", "Checkpoint_AfterQueen", "ST_Queen_001_Checkpoint", true)
 end
 function s100_area10.OnBabyCreationCutsceneTrigger()
-  -- if not Scenario.ReadFromBlackboard("firstTimeMetroidHatchlingIntroPlayed", false) then
+  if not Scenario.ReadFromBlackboard("firstTimeMetroidHatchlingIntroPlayed", false) then
   --   Game.LaunchCutscene("cutscenes/metroidhatchlingintro/takes/01/metroidhatchlingintro01.bmscu")
-  --   if Game.GetEntity("TG_Intro_BabyHatchling") ~= nil then
+    if Game.GetEntity("TG_Intro_BabyHatchling") ~= nil then
       Game.SetSubAreasPreferredTransitionType("None")
       Game.GetEntity("TG_Intro_BabyHatchling").TRIGGER:DisableTrigger()
-  --   end
-  -- end
+    end
+  end
 end
 function s100_area10.OnMetroidHatchlingIntroCutsceneLaunch()
-  Scenario.WriteToBlackboard("firstTimeMetroidHatchlingIntroPlayed", "b", true)
+  if Scenario.ReadFromBlackboard("firstTimeMetroidHatchlingIntroPlayed", true) then
   -- if Game.GetDefaultPlayer() ~= nil then
   --   Game.GetDefaultPlayer().BABYHATCHLINGCREATION:SpawnBaby()
   --   Game.GetDefaultPlayer().GUN:SelectGun("IceBeam", true)
   -- end
-  Game.SetSceneGroupEnabledByName("sg_egg01", false)
-  Game.SetSceneGroupEnabledByName("sg_egg02", false)
+    Game.SetSceneGroupEnabledByName("sg_egg01", false)
+    Game.SetSceneGroupEnabledByName("sg_egg02", false)
+  end
 end
 function s100_area10.OnMetroidHatchlingIntroCutsceneLastTake()
   Game.SetSceneGroupEnabledByName("sg_egg02", true)
   Game.SetSubAreaCurrentSetup("collision_camera_022", "PostMetroids_001", true)
 end
 function s100_area10.OnMetroidHatchlingIntroCutsceneEnd()
-  -- Game.SetSubAreaCurrentSetup("collision_camera_020", "PostBabyHatchling", true)
+  Game.SetSubAreaCurrentSetup("collision_camera_020", "PostBabyHatchling", true)
   if Game.GetEntity("TG_ChangeEggMetroid") ~= nil then
     Game.GetEntity("TG_ChangeEggMetroid").TRIGGER:EnableTrigger()
   end

--- a/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -72,6 +72,7 @@ function s100_area10.TestMetroidCount()
   Game.GetPlayer().vPos = V3D(-4459.72, 10426.6, 0)
 end
 function s100_area10.InitFromBlackboard()
+  Scenario.WriteToBlackboard("firstTimeMetroidHatchlingIntroPlayed", "b", true)
   if Game.GetEntity("LE_ValveQueen") ~= nil then
     if Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") ~= nil and s100_area10.iNumMetroids == Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") then
       Game.GetEntity("LE_ValveQueen").MODELUPDATER:SetMeshVisible("Valve", false)
@@ -347,7 +348,6 @@ function s100_area10.OnQueenGenerated(_ARG_0_, _ARG_1_)
   end
 end
 function s100_area10.OnQueenDead(_ARG_0_)
-  Scenario.WriteToBlackboard("firstTimeMetroidHatchlingIntroPlayed", "b", true)
   Blackboard.SetProp("DEFEATED_ENEMIES", "Queen", "i", 1)
   Game.SetSubAreaCurrentSetup("collision_camera_020", "PostMetroids_001", true)
   Game.LaunchCutscene("cutscenes/metroidqueendeath/takes/01/metroidqueendeath01.bmscu")

--- a/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -375,20 +375,20 @@ function s100_area10.OnEndQueenDeathCutscene()
   Game.SaveGame("checkpoint", "Checkpoint_AfterQueen", "ST_Queen_001_Checkpoint", true)
 end
 function s100_area10.OnBabyCreationCutsceneTrigger()
-  if not Scenario.ReadFromBlackboard("firstTimeMetroidHatchlingIntroPlayed", false) then
-    Game.LaunchCutscene("cutscenes/metroidhatchlingintro/takes/01/metroidhatchlingintro01.bmscu")
-    if Game.GetEntity("TG_Intro_BabyHatchling") ~= nil then
+  -- if not Scenario.ReadFromBlackboard("firstTimeMetroidHatchlingIntroPlayed", false) then
+  --   Game.LaunchCutscene("cutscenes/metroidhatchlingintro/takes/01/metroidhatchlingintro01.bmscu")
+  --   if Game.GetEntity("TG_Intro_BabyHatchling") ~= nil then
       Game.SetSubAreasPreferredTransitionType("None")
       Game.GetEntity("TG_Intro_BabyHatchling").TRIGGER:DisableTrigger()
-    end
-  end
+  --   end
+  -- end
 end
 function s100_area10.OnMetroidHatchlingIntroCutsceneLaunch()
   Scenario.WriteToBlackboard("firstTimeMetroidHatchlingIntroPlayed", "b", true)
-  if Game.GetDefaultPlayer() ~= nil then
-    Game.GetDefaultPlayer().BABYHATCHLINGCREATION:SpawnBaby()
-    Game.GetDefaultPlayer().GUN:SelectGun("IceBeam", true)
-  end
+  -- if Game.GetDefaultPlayer() ~= nil then
+  --   Game.GetDefaultPlayer().BABYHATCHLINGCREATION:SpawnBaby()
+  --   Game.GetDefaultPlayer().GUN:SelectGun("IceBeam", true)
+  -- end
   Game.SetSceneGroupEnabledByName("sg_egg01", false)
   Game.SetSceneGroupEnabledByName("sg_egg02", false)
 end
@@ -397,7 +397,7 @@ function s100_area10.OnMetroidHatchlingIntroCutsceneLastTake()
   Game.SetSubAreaCurrentSetup("collision_camera_022", "PostMetroids_001", true)
 end
 function s100_area10.OnMetroidHatchlingIntroCutsceneEnd()
-  Game.SetSubAreaCurrentSetup("collision_camera_020", "PostBabyHatchling", true)
+  -- Game.SetSubAreaCurrentSetup("collision_camera_020", "PostBabyHatchling", true)
   if Game.GetEntity("TG_ChangeEggMetroid") ~= nil then
     Game.GetEntity("TG_ChangeEggMetroid").TRIGGER:EnableTrigger()
   end

--- a/open_samus_returns_rando/files/randomizer_powerup.lua
+++ b/open_samus_returns_rando/files/randomizer_powerup.lua
@@ -160,3 +160,10 @@ function RandomizerGravitySuit.OnPickedUp(actor, progression)
     Game.GetEntity("Samus").MODELUPDATER.sModelAlias = "Gravity"
     RandomizerPowerup.EnableLiquids()
 end
+
+RandomizerBabyHatchling = {}
+setmetatable(RandomizerBabyHatchling, {__index = RandomizerPowerup})
+function RandomizerBabyHatchling.OnPickedUp(actor, progression)
+    RandomizerPowerup.OnPickedUp(actor, progression)
+    Game.GetDefaultPlayer("Samus").BABYHATCHLINGCREATION:SpawnBaby()
+end

--- a/open_samus_returns_rando/files/schema.json
+++ b/open_samus_returns_rando/files/schema.json
@@ -149,6 +149,31 @@
                 "additionalProperties": false
             },
             "default": []
+        },
+        "custom_pickups": {
+            "type": "array",
+            "description": "Creates new pickups",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "new_actor": {
+                        "$ref": "#/$defs/actor_reference"
+                    },
+                    "location": {
+                        "$ref": "#/$defs/position"
+                    },
+                    "collision_camera_name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "new_actor",
+                    "location",
+                    "collision_camera_name"
+                ],
+                "additionalProperties": false
+            },
+            "default": []
         }
     },
     "required": [

--- a/open_samus_returns_rando/lua_editor.py
+++ b/open_samus_returns_rando/lua_editor.py
@@ -17,6 +17,7 @@ def _read_level_lua(level_id: str) -> str:
 SPECIFIC_CLASSES = {
     "ITEM_VARIA_SUIT": "RandomizerVariaSuit",
     "ITEM_GRAVITY_SUIT": "RandomizerGravitySuit",
+    "ITEM_BABY_HATCHLING": "RandomizerBabyHatchling"
 }
 
 

--- a/open_samus_returns_rando/model_data.py
+++ b/open_samus_returns_rando/model_data.py
@@ -38,6 +38,22 @@ ALL_MODEL_DATA: dict[str, ModelData] = {
         ),
     ),
 
+    "babyhatchling": ModelData(
+        bcmdl_path="actors/characters/babyhatchling/models/babyhatchling.bcmdl",
+        dependencies=(
+            "actors/characters/babyhatchling/charclasses/babyhatchling.bmsad",
+            "actors/characters/babyhatchling/models/babyhatchling.bcmdl",
+            "actors/characters/babyhatchling/models/babyhatchlingcutscene.bcmdl",
+            "actors/characters/babyhatchling/models/babyhatchlingsmall.bcmdl",
+            "actors/characters/babyhatchling/models/hatchling_telecolor.bcmdl",
+            "actors/characters/babyhatchling/models/hatchling_teledisolve.bcmdl",
+            "actors/characters/babyhatchling/models/textures/babyhatchling_a.bctex",
+            "actors/characters/babyhatchling/models/textures/babyhatchling_d.bctex",
+            "actors/characters/babyhatchling/models/textures/coreveins.bctex",
+            "actors/characters/babyhatchling/models/textures/cubemetroids.bctex"
+        ),
+    ),
+
     "powerup_wavebeam": ModelData(
         bcmdl_path="actors/items/powerup_wavebeam/models/powerup_wavebeam.bcmdl",
         dependencies=(

--- a/open_samus_returns_rando/samus_returns_patcher.py
+++ b/open_samus_returns_rando/samus_returns_patcher.py
@@ -90,6 +90,21 @@ def patch_spawn_points(editor: PatcherEditor, spawn_config: list[dict]):
         eg_collison_camera = next((sub_area for sub_area in scenario.raw.sub_areas if sub_area.name ==  eg_name), None)
         eg_collison_camera.names.append(new_actor_name)
 
+def patch_custom_pickups(editor: PatcherEditor, pickup_config: list[dict]):
+    # create custom pickup
+        _EXAMPLE_PICKUP = {"scenario": "s000_surface", "layer": "9", "actor": "LE_PowerUP_Morphball"}
+        base_actor = editor.resolve_actor_reference(_EXAMPLE_PICKUP)
+        for new_pickup in pickup_config:
+            scenario_name = new_pickup["new_actor"]["scenario"]
+            new_actor_name = new_pickup["new_actor"]["actor"]
+            collision_camera_name = new_pickup["collision_camera_name"]
+            new_pickup_pos = (new_pickup["location"]["x"], new_pickup["location"]["y"], new_pickup["location"]["z"])
+            scenario = editor.get_scenario(scenario_name)
+            editor.copy_actor(scenario_name, new_pickup_pos, base_actor, new_actor_name, 9)
+            eg_name = f"eg_SubArea_{collision_camera_name}"
+            eg_collison_camera = next((sub_area for sub_area in scenario.raw.sub_areas if sub_area.name ==  eg_name), None)
+            eg_collison_camera.names.append(new_actor_name)
+
 def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
     LOG.info("Will patch files from %s", input_path)
 
@@ -113,6 +128,9 @@ def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
     # Add custom lua files
     lua_util.replace_script(editor, "system/scripts/scenario", "custom_scenario.lua")
     lua_util.replace_script(editor, "actors/characters/player/scripts/player", "custom_player.lua")
+
+    # custom pickups
+    patch_custom_pickups(editor, configuration["custom_pickups"])
 
     # Patch all pickups
     patch_pickups(editor, lua_scripts, configuration["pickups"], configuration)

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -83,5 +83,19 @@
         "reveal_map_on_start": true,
         "game_patches": {
           "nerf_power_bombs": true
-        }
+        },
+        "custom_pickups": [
+          {
+              "new_actor": {
+                  "actor": "LE_BabyHatching",
+                  "scenario": "s100_area10"
+              },
+              "location": {
+                  "x": -3400.0,
+                  "y": 11225.0,
+                  "z": 0.0
+              },
+              "collision_camera_name": "collision_camera_026"
+          }
+      ]
       }

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -76,7 +76,26 @@
               "actor": "LE_Item_001"
             },
             "model": ["powerup_wavebeam", "powerup_spazerbeam",  "powerup_plasmabeam"]
-          }
+          },
+          {
+            "pickup_type": "actor",
+            "caption": "Screw Attack acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SCREW_ATTACK",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+            "scenario": "s100_area10",
+            "actor": "LE_Baby_Hatching"
+            },
+            "model": [
+                "powerup_screwattack"
+            ]
+        }
         ],
         "energy_per_tank": 100,
         "aeion_per_tank": 50,
@@ -87,7 +106,7 @@
         "custom_pickups": [
           {
               "new_actor": {
-                  "actor": "LE_BabyHatching",
+                  "actor": "LE_Baby_Hatching",
                   "scenario": "s100_area10"
               },
               "location": {
@@ -95,7 +114,7 @@
                   "y": 11225.0,
                   "z": 0.0
               },
-              "collision_camera_name": "collision_camera_026"
+              "collision_camera_name": "collision_camera_022"
           }
       ]
       }


### PR DESCRIPTION
The Baby location can now be shuffled, as well at the Baby being shuffle-able to other pickup locations

Fixes #18 
Related to #40 