### PR TITLE
Support option to remove grapple blocks

### DIFF
--- a/open_samus_returns_rando/files/schema.json
+++ b/open_samus_returns_rando/files/schema.json
@@ -120,7 +120,12 @@
                 "nerf_power_bombs": {
                     "type": "boolean",
                     "description": "Changes weaknesses for certain props to make Power Bombs less overpowered.",
-                    "default": false
+                    "default": true
+                },
+                "remove_elevator_grapple_blocks": {
+                    "type": "boolean",
+                    "description": "Removes the Grapple Blocks in the paths exiting areas.",
+                    "default": true
                 }
             },
             "additionalProperties": false

--- a/open_samus_returns_rando/files/schema.json
+++ b/open_samus_returns_rando/files/schema.json
@@ -124,8 +124,13 @@
                 },
                 "remove_elevator_grapple_blocks": {
                     "type": "boolean",
-                    "description": "Removes the Grapple Blocks in the paths exiting areas.",
+                    "description": "Remove the Grapple Blocks in the exit paths to the connecting areas.",
                     "default": true
+                },
+                "remove_grapple_block_area3_interior_shortcut": {
+                    "type": "boolean",
+                    "description": "Remove the Grapple Block in the path to Area 3 Interior (West) from Area 3 Interior (East).",
+                    "default": false
                 }
             },
             "additionalProperties": false

--- a/open_samus_returns_rando/patcher_editor.py
+++ b/open_samus_returns_rando/patcher_editor.py
@@ -56,3 +56,10 @@ class PatcherEditor(FileTreeEditor):
         newActor.z = coords[2] + offset[2]
 
         return newActor
+    
+    def remove_entity(self, reference: dict):
+        scenario = self.get_scenario(reference["scenario"])
+        layer = reference.get("layer", "default")
+        actor_name = reference["actor"]
+
+        scenario.raw.actors[layer].pop(actor_name)

--- a/open_samus_returns_rando/patcher_editor.py
+++ b/open_samus_returns_rando/patcher_editor.py
@@ -47,7 +47,7 @@ class PatcherEditor(FileTreeEditor):
         self.memory_files = {}
 
     def copy_actor(self, scenario: str, coords, template_actor: Container, new_name: str,
-                   layer_index: int, offset: tuple = (0, 0, 0)):       
+                   layer_index: int, offset: tuple = (0, 0, 0)):
         new_actor = copy.deepcopy(template_actor)
         current_scenario = self.get_scenario(scenario)
         current_scenario.raw.actors[layer_index][new_name] = new_actor

--- a/open_samus_returns_rando/specific_patches/game_patches.py
+++ b/open_samus_returns_rando/specific_patches/game_patches.py
@@ -63,3 +63,12 @@ def _remove_grapple_blocks(editor: PatcherEditor, configuration: dict):
     if configuration["remove_elevator_grapple_blocks"]:
         for reference in _ELEVATOR_GRAPPLE_BLOCKS:
             editor.remove_entity(reference)
+
+    if configuration["remove_grapple_block_area3_interior_shortcut"]:
+        editor.remove_entity(
+            {
+                "scenario": "s036_area3c",
+                "layer": 9,
+                "actor": "LE_GrappleDest_004"
+            }
+        )

--- a/open_samus_returns_rando/specific_patches/game_patches.py
+++ b/open_samus_returns_rando/specific_patches/game_patches.py
@@ -2,11 +2,39 @@ from mercury_engine_data_structures.formats import Bmsad
 
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
+_ELEVATOR_GRAPPLE_BLOCKS = [
+    {
+        # Area 4 West to Area 4 East
+        "scenario": "s040_area4",
+        "layer": 9,
+        "actor": "LE_GrappleMov_001"
+    },
+    {
+        # Area 5 to Area 6
+        "scenario": "s060_area6",
+        "layer": 9,
+        "actor": "LE_GrappleMov_004"
+    },
+    {
+        # Area 6 to Area 7
+        "scenario": "s070_area7",
+        "layer": 9,
+        "actor": "LE_GrappleMov_001"
+    },
+    {
+        # Area 7 to Area 8
+        "scenario": "s090_area9",
+        "layer": 9,
+        "actor": "LE_GrappleMov_001"
+    }
+]
 
 def apply_game_patches(editor: PatcherEditor, configuration: dict):
 
     if configuration["nerf_power_bombs"]:
         _remove_pb_weaknesses(editor)
+
+    _remove_grapple_blocks(editor, configuration)
 
 def _remove_pb_weaknesses(editor: PatcherEditor):
     # Charge Door
@@ -30,3 +58,8 @@ def _remove_pb_weaknesses(editor: PatcherEditor):
                 func_wp.params.Param1.value = "PLASMA_BEAM"
         if func_s.params.Param1.value:
             func_s.params.Param1.value = "SPAZER_BEAM"
+
+def _remove_grapple_blocks(editor: PatcherEditor, configuration: dict):
+    if configuration["remove_elevator_grapple_blocks"]:
+        for reference in _ELEVATOR_GRAPPLE_BLOCKS:
+            editor.remove_entity(reference)

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -101,7 +101,8 @@
         "aeion_per_tank": 50,
         "reveal_map_on_start": true,
         "game_patches": {
-          "nerf_power_bombs": true
+          "nerf_power_bombs": true,
+          "remove_elevator_grapple_blocks": true
         },
         "custom_pickups": [
           {

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -102,7 +102,8 @@
         "reveal_map_on_start": true,
         "game_patches": {
           "nerf_power_bombs": true,
-          "remove_elevator_grapple_blocks": true
+          "remove_elevator_grapple_blocks": true,
+          "remove_grapple_block_area3_interior_shortcut": false
         },
         "custom_pickups": [
           {

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -103,7 +103,7 @@
         "game_patches": {
           "nerf_power_bombs": true,
           "remove_elevator_grapple_blocks": true,
-          "remove_grapple_block_area3_interior_shortcut": false
+          "remove_grapple_block_area3_interior_shortcut": true
         },
         "custom_pickups": [
           {


### PR DESCRIPTION
Related to #57

Shortcut option disabled
![Metroid Samus Returns_30 08 23_21 05 26 796](https://github.com/randovania/open-samus-returns-rando/assets/38679103/c4cc857c-1e13-410a-8e5a-bdc3e46e10bb)

Shortcut option enabled
![Metroid Samus Returns_30 08 23_21 04 45 363](https://github.com/randovania/open-samus-returns-rando/assets/38679103/671d0ab3-a6c9-47ce-8c6d-bb967eff85ef)

