### PR TITLE
Fix heat sound not playing

### DIFF
--- a/open_samus_returns_rando/files/heatzone.lua
+++ b/open_samus_returns_rando/files/heatzone.lua
@@ -1,0 +1,40 @@
+HeatZone = {}
+function HeatZone.main()
+end
+function HeatZone.OnPlayerDead()
+  Game.GetPlayerInfo():ResetHeatZoneCount()
+  Game.GetPlayer():StopEntityLoopWithFade("actors/samus/damage_alarm.wav", 0.6)
+end
+function HeatZone.OnEnter(_ARG_0_, _ARG_1_, _ARG_2_)
+  if _ARG_2_ == true then
+    HeatZone.OnEnter()
+  end
+end
+function HeatZone.PlaySound()
+  Game.GetPlayer():PlayEntityLoop("actors/samus/damage_alarm.wav", 0.4, 100000, 110000, 1, false)
+  Game.PlayEntitySound("levels/lava_pain_0" .. math.random(2) .. ".wav", Game.GetPlayer().sName, 0.45, 500, 5000, 0.9)
+end 
+
+function HeatZone.OnEnter()
+  if Game.GetPlayerInfo().iHeatZoneCount == 0 and Game.GetVariaSuitOn() < 1 then
+    Game.AddSF(0.0, "HeatZone.PlaySound", "")
+    guicallbacks.OnPlayerContinuousDamageStart()
+    utils.LOG(utils.LOGTYPE_LOGIC, "heatzoneenter")
+  end
+  Game.GetPlayerInfo():IncrementHeatZoneCount()
+end
+function HeatZone.OnExit(_ARG_0_, _ARG_1_, _ARG_2_)
+  if _ARG_2_ == true then
+    HeatZone.OnExit()
+  end
+end
+function HeatZone.OnExit()
+  Game.GetPlayerInfo():DecrementHeatZoneCount()
+  if Game.GetPlayerInfo().iHeatZoneCount == 0 then
+    Game.GetPlayer():StopEntityLoopWithFade("actors/samus/damage_alarm.wav", 0.6)
+    guicallbacks.OnPlayerContinuousDamageEnd()
+    utils.LOG(utils.LOGTYPE_LOGIC, "heatzoneexit")
+  elseif Game.GetPlayerInfo().iHeatZoneCount < 0 then
+    Game.GetPlayerInfo():ResetHeatZoneCount()
+  end
+end

--- a/open_samus_returns_rando/lua_editor.py
+++ b/open_samus_returns_rando/lua_editor.py
@@ -110,5 +110,7 @@ class LuaEditor:
 
     def save_modifications(self, editor: PatcherEditor):
         editor.replace_asset("actors/items/randomizer_powerup/scripts/randomizer_powerup.lc", self._powerup_script)
+        editor.replace_asset("actors/props/heatzone/scripts/heatzone.lc",
+                             files_path().joinpath("heatzone.lua").read_bytes())
         for scenario, script in self._custom_level_scripts.items():
             editor.replace_asset(path_for_level(scenario) + ".lc", script["script"].encode("utf-8"))


### PR DESCRIPTION
Something in some rooms make the sound immediately stop.
I delay it now to the next game loop cycle with `Game.AddSF(0.0, "HeatZone.PlaySound", "")` and it worked in the room in area4 and area5.
I hope that it fixes all rooms