### PR TITLE
Support option for removing crumble blocks in S and A1

### DIFF
--- a/open_samus_returns_rando/files/schema.json
+++ b/open_samus_returns_rando/files/schema.json
@@ -139,9 +139,14 @@
                     "description": "Removes the Super Missile weakness on Missile shields.",
                     "default": false
                 },
-                "patch_crumble_blocks": {
+                "patch_surface_crumbles": {
                     "type": "boolean",
-                    "description": "Changes the Crumble blocks after Scan Pulse and leaving Area 1 to be Power Beam blocks.",
+                    "description": "Changes the Crumble blocks after Scan Pulse to be Power Beam blocks.",
+                    "default": true
+                },
+                "patch_area1_crumbles": {
+                    "type": "boolean",
+                    "description": "Changes the Crumble blocks leaving Area 1 to be Power Beam blocks.",
                     "default": true
                 }
             },

--- a/open_samus_returns_rando/files/schema.json
+++ b/open_samus_returns_rando/files/schema.json
@@ -138,6 +138,11 @@
                     "type": "boolean",
                     "description": "Removes the Super Missile weakness on Missile shields.",
                     "default": false
+                },
+                "patch_crumble_blocks": {
+                    "type": "boolean",
+                    "description": "Changes the Crumble blocks after Scan Pulse and leaving Area 1 to be Power Beam blocks.",
+                    "default": true
                 }
             },
             "additionalProperties": false

--- a/open_samus_returns_rando/specific_patches/game_patches.py
+++ b/open_samus_returns_rando/specific_patches/game_patches.py
@@ -99,9 +99,9 @@ def _patch_crumble_blocks(editor: PatcherEditor, configuration: dict):
         )
         post_scan_pulse_crumbles = surface.raw["block_groups"][37]
         post_scan_pulse_crumbles["types"][0]["block_type"] = "power_beam"
-        post_scan_pulse_crumbles["types"][0]["blocks"][0]["unk4"] = 0.0
-        post_scan_pulse_crumbles["types"][0]["blocks"][1]["unk4"] = 0.0
-        post_scan_pulse_crumbles["types"][0]["blocks"][2]["unk4"] = 0.0
+        post_scan_pulse_crumbles["types"][0]["blocks"][0]["respawn_time"] = 0.0
+        post_scan_pulse_crumbles["types"][0]["blocks"][1]["respawn_time"] = 0.0
+        post_scan_pulse_crumbles["types"][0]["blocks"][2]["respawn_time"] = 0.0
 
     # Crumble blocks leaving Area 1
     if configuration["patch_area1_crumbles"]:
@@ -110,8 +110,8 @@ def _patch_crumble_blocks(editor: PatcherEditor, configuration: dict):
         )
         area1_chozo_seal_crumbles = area1.raw["block_groups"][19]
         area1_chozo_seal_crumbles["types"][0]["block_type"] = "power_beam"
-        area1_chozo_seal_crumbles["types"][0]["blocks"][0]["unk4"] = 0.0
-        area1_chozo_seal_crumbles["types"][0]["blocks"][1]["unk4"] = 0.0
-        area1_chozo_seal_crumbles["types"][0]["blocks"][2]["unk4"] = 0.0
-        area1_chozo_seal_crumbles["types"][0]["blocks"][3]["unk4"] = 0.0
-        area1_chozo_seal_crumbles["types"][0]["blocks"][4]["unk4"] = 0.0
+        area1_chozo_seal_crumbles["types"][0]["blocks"][0]["respawn_time"] = 0.0
+        area1_chozo_seal_crumbles["types"][0]["blocks"][1]["respawn_time"] = 0.0
+        area1_chozo_seal_crumbles["types"][0]["blocks"][2]["respawn_time"] = 0.0
+        area1_chozo_seal_crumbles["types"][0]["blocks"][3]["respawn_time"] = 0.0
+        area1_chozo_seal_crumbles["types"][0]["blocks"][4]["respawn_time"] = 0.0

--- a/open_samus_returns_rando/specific_patches/game_patches.py
+++ b/open_samus_returns_rando/specific_patches/game_patches.py
@@ -40,9 +40,7 @@ def apply_game_patches(editor: PatcherEditor, configuration: dict):
 
     # Area patches
     _remove_grapple_blocks(editor, configuration)
-
-    if configuration["patch_crumble_blocks"]:
-        _patch_crumble_blocks(editor)
+    _patch_crumble_blocks(editor, configuration)
 
 
 def _remove_pb_weaknesses(editor: PatcherEditor):
@@ -93,23 +91,27 @@ def _remove_super_missile_weakness(editor: PatcherEditor):
         func.params.Param1.value = "MISSILE"
 
 
-def _patch_crumble_blocks(editor: PatcherEditor):
+def _patch_crumble_blocks(editor: PatcherEditor, configuration: dict):
     # Crumble blocks after Scan Pulse
-    surface = editor.get_file(
-        "maps/levels/c10_samus/s000_surface/s000_surface.bmsbk", Bmsbk
-    )
-    post_scan_pulse_crumbles = surface.raw["block_groups"][37]
-    post_scan_pulse_crumbles["types"][0]["block_type"] = "power_beam"
-    post_scan_pulse_crumbles["types"][0]["blocks"][0]["unk4"] = 0.0
-    post_scan_pulse_crumbles["types"][0]["blocks"][1]["unk4"] = 0.0
-    post_scan_pulse_crumbles["types"][0]["blocks"][2]["unk4"] = 0.0
+    if configuration["patch_surface_crumbles"]:
+        surface = editor.get_file(
+            "maps/levels/c10_samus/s000_surface/s000_surface.bmsbk", Bmsbk
+        )
+        post_scan_pulse_crumbles = surface.raw["block_groups"][37]
+        post_scan_pulse_crumbles["types"][0]["block_type"] = "power_beam"
+        post_scan_pulse_crumbles["types"][0]["blocks"][0]["unk4"] = 0.0
+        post_scan_pulse_crumbles["types"][0]["blocks"][1]["unk4"] = 0.0
+        post_scan_pulse_crumbles["types"][0]["blocks"][2]["unk4"] = 0.0
 
     # Crumble blocks leaving Area 1
-    area1 = editor.get_file("maps/levels/c10_samus/s010_area1/s010_area1.bmsbk", Bmsbk)
-    area1_chozo_seal_crumbles = area1.raw["block_groups"][19]
-    area1_chozo_seal_crumbles["types"][0]["block_type"] = "power_beam"
-    area1_chozo_seal_crumbles["types"][0]["blocks"][0]["unk4"] = 0.0
-    area1_chozo_seal_crumbles["types"][0]["blocks"][1]["unk4"] = 0.0
-    area1_chozo_seal_crumbles["types"][0]["blocks"][2]["unk4"] = 0.0
-    area1_chozo_seal_crumbles["types"][0]["blocks"][3]["unk4"] = 0.0
-    area1_chozo_seal_crumbles["types"][0]["blocks"][4]["unk4"] = 0.0
+    if configuration["patch_area1_crumbles"]:
+        area1 = editor.get_file(
+            "maps/levels/c10_samus/s010_area1/s010_area1.bmsbk", Bmsbk
+        )
+        area1_chozo_seal_crumbles = area1.raw["block_groups"][19]
+        area1_chozo_seal_crumbles["types"][0]["block_type"] = "power_beam"
+        area1_chozo_seal_crumbles["types"][0]["blocks"][0]["unk4"] = 0.0
+        area1_chozo_seal_crumbles["types"][0]["blocks"][1]["unk4"] = 0.0
+        area1_chozo_seal_crumbles["types"][0]["blocks"][2]["unk4"] = 0.0
+        area1_chozo_seal_crumbles["types"][0]["blocks"][3]["unk4"] = 0.0
+        area1_chozo_seal_crumbles["types"][0]["blocks"][4]["unk4"] = 0.0

--- a/tests/test_files/crumble_blocks.json
+++ b/tests/test_files/crumble_blocks.json
@@ -1,0 +1,68 @@
+{
+    "$schema": "../../open_samus_returns_rando/files/schema.json",
+        "starting_location": {
+          "scenario": "s000_surface",
+          "actor": "ST_CheckPoint_001"
+        },
+        "starting_items": {
+          "ITEM_MAX_LIFE": 99,
+          "ITEM_WEAPON_MISSILE_MAX": 50,
+          "ITEM_WEAPON_SUPER_MISSILE_MAX": 5,
+          "ITEM_WEAPON_POWER_BOMB_MAX": 0,
+          "ITEM_MAX_SPECIAL_ENERGY": 1000,
+          "ITEM_SPECIAL_ENERGY_SCANNING_PULSE": 1,
+          "ITEM_MORPH_BALL": 1,
+          "ITEM_ENERGY_TANKS": 4,
+          "ITEM_WEAPON_BOMB": 1,
+          "ITEM_WEAPON_WAVE_BEAM": 1,
+          "ITEM_METROID_COUNT": 0,
+          "ITEM_METROID_TOTAL_COUNT": 40,
+          "ITEM_SPACE_JUMP": 1
+          
+        },
+        "pickups": [
+          {
+            "pickup_type": "actor",
+            "caption": "Screw Attack acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SCREW_ATTACK",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+            "scenario": "s100_area10",
+            "actor": "LE_Baby_Hatching"
+            },
+            "model": [
+                "powerup_screwattack"
+            ]
+        }
+        ],
+        "energy_per_tank": 100,
+        "aeion_per_tank": 50,
+        "reveal_map_on_start": true,
+        "game_patches": {
+          "nerf_power_bombs": true,
+          "remove_elevator_grapple_blocks": true,
+          "remove_grapple_block_area3_interior_shortcut": true,
+          "patch_crumble_blocks": false
+        },
+        "custom_pickups": [
+          {
+              "new_actor": {
+                  "actor": "LE_Baby_Hatching",
+                  "scenario": "s100_area10"
+              },
+              "location": {
+                  "x": -3400.0,
+                  "y": 11225.0,
+                  "z": 0.0
+              },
+              "collision_camera_name": "collision_camera_022"
+          }
+      ]
+      }
+  


### PR DESCRIPTION
Adds an option to change the crumble blocks after Scan Pulse and leaving Area 1 to be Power Beam blocks. This is to open up the rando a bit more. These changes affect the following:
- For Surface, this means that a player can more safely access the Alpha section without being forced to have/find Charge Beam to leave the area.
- For Area 1, this means that Spider Ball is no longer hard required to leave the area. Even though Phase Drift can be an alternative to Spider, Spider is more likely to be placed early due to its overall usefulness.

I couldn't figure out how to delete the blocks and remove the textures, as the textures seem to be left behind. A more ideal situation would be to remove the blocks entirely. Might also be worth splitting this option up in the future, as they are similar, but achieve different goals. This also would affect trick logic, as there are a few methods to bypass the Area 1 blocks with tricks, but this makes most of those pointless, which IMO is not a good thing.

Related to #57 