### PR TITLE
Remove parentheses

### DIFF
--- a/open_samus_returns_rando/files/custom_savestation.lua
+++ b/open_samus_returns_rando/files/custom_savestation.lua
@@ -10,5 +10,5 @@ function SaveStation.WarpToStart()
 end
 function SaveStation.OnDialogDeclined()
   Usable._oUsableObject.USABLE:OnDialogDeclined()
-  GUI.LaunchMessage("Warp to Start?", "SaveStation.WarpToStart", " SaveStation.Dummy()")
+  GUI.LaunchMessage("Warp to Start?", "SaveStation.WarpToStart", " SaveStation.Dummy")
 end

--- a/open_samus_returns_rando/files/custom_ship.lua
+++ b/open_samus_returns_rando/files/custom_ship.lua
@@ -10,5 +10,5 @@ function SamusShip.WarpToStart()
 end
 function SamusShip.OnDialogDeclined()
   Usable._oUsableObject.USABLE:OnDialogDeclined()
-  GUI.LaunchMessage("Warp to Start?", "SamusShip.WarpToStart", " SamusShip.Dummy()")
+  GUI.LaunchMessage("Warp to Start?", "SamusShip.WarpToStart", " SamusShip.Dummy")
 end


### PR DESCRIPTION
Copy & Paste error. It defines a function to call so parentheses needs to be removed.