### PR TITLE
Fix One-Way Locked Doors with Beam Covers

### DIFF
--- a/open_samus_returns_rando/specific_patches/door_patches.py
+++ b/open_samus_returns_rando/specific_patches/door_patches.py
@@ -193,8 +193,8 @@ def _patch_one_way_doors(editor: PatcherEditor):
 
 
 def patch_doors(editor: PatcherEditor):
+    _patch_one_way_doors(editor)
     _patch_missile_covers(editor)
     _patch_beam_bmsads(editor)
     _patch_beam_covers(editor)
     _patch_charge_doors(editor)
-    _patch_one_way_doors(editor)

--- a/open_samus_returns_rando/specific_patches/door_patches.py
+++ b/open_samus_returns_rando/specific_patches/door_patches.py
@@ -189,8 +189,7 @@ def _patch_one_way_doors(editor: PatcherEditor):
         for door in doors:
             properties = scenario.raw.actors[15][door]
             properties.type = "doorpowerpower"
-            if door in {"Door008", "Door012"}:
-                properties.components[0]["arguments"][2]["value"] = True
+            properties.components[0]["arguments"][2]["value"] = False
 
 
 def patch_doors(editor: PatcherEditor):

--- a/open_samus_returns_rando/specific_patches/door_patches.py
+++ b/open_samus_returns_rando/specific_patches/door_patches.py
@@ -174,8 +174,6 @@ def _patch_one_way_doors(editor: PatcherEditor):
     ONE_WAY_DOORS = {
         # Bombs, Right Exterior Door -> Interior, Exterior Alpha
         "s010_area1": ["Door004", "Door012", "Door016"],
-        # Below Wave Beam
-        "s025_area2b": ["Door008"],
         # Below Chozo Seal
         "s030_area3": ["Door003", "Door006"],
         # Chozo Seal Spazer Door
@@ -189,7 +187,8 @@ def _patch_one_way_doors(editor: PatcherEditor):
         for door in doors:
             properties = scenario.raw.actors[15][door]
             properties.type = "doorpowerpower"
-            properties.components[0]["arguments"][2]["value"] = False
+            if door == "Door012":
+                properties.components[0]["arguments"][2]["value"] = True
 
 
 def patch_doors(editor: PatcherEditor):

--- a/open_samus_returns_rando/specific_patches/door_patches.py
+++ b/open_samus_returns_rando/specific_patches/door_patches.py
@@ -174,6 +174,8 @@ def _patch_one_way_doors(editor: PatcherEditor):
     ONE_WAY_DOORS = {
         # Bombs, Right Exterior Door -> Interior, Exterior Alpha
         "s010_area1": ["Door004", "Door012", "Door016"],
+        # Below Wave Beam
+        "s025_area2b": ["Door008"],
         # Below Chozo Seal
         "s030_area3": ["Door003", "Door006"],
         # Chozo Seal Spazer Door
@@ -187,7 +189,7 @@ def _patch_one_way_doors(editor: PatcherEditor):
         for door in doors:
             properties = scenario.raw.actors[15][door]
             properties.type = "doorpowerpower"
-            if door == "Door012":
+            if door in {"Door008", "Door012"}:
                 properties.components[0]["arguments"][2]["value"] = True
 
 


### PR DESCRIPTION
The flag that changed one-way doors to act like two-way doors wasn't being set for the copied beam covers. Calling the one-way patch first fixes this issue.