### PR TITLE
Fix Metroids

### DIFF
--- a/open_samus_returns_rando/files/custom_scenario.lua
+++ b/open_samus_returns_rando/files/custom_scenario.lua
@@ -72,8 +72,9 @@ function Scenario.OnSubAreaChange(old_subarea, old_actorgroup, new_subarea, new_
   Scenario.UpdateProgressiveItemModels()
 end
 
-function Scenario.SetMetroidSpawngroupOnCurrentScenario(created_actor, group_name)
+function Scenario.SetMetroidSpawngroupOnCurrentScenario(created_actor, group_name, is_multi)
   if created_actor ~= nil and created_actor.sName ~= nil then
     CurrentScenario.currentMetroidSpawngroup = group_name
+    CurrentScenario.isMultiGamma = is_multi or false
   end
 end

--- a/open_samus_returns_rando/files/levels/s025_area2b.lua
+++ b/open_samus_returns_rando/files/levels/s025_area2b.lua
@@ -82,7 +82,7 @@ function s025_area2b.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_
   if _ARG_3_ ~= "PostVariaSuit" then
     Game.SetSubAreaEnvironmentLocked(false, false, false)
   end
-  if (_ARG_0_ == "collision_camera012" or _ARG_0_ == "collision_camera011") and _ARG_2_ == "collision_camera037" and not Scenario.ReadFromBlackboard("GammaIntroCutscenePlayed", false) then
+  if _ARG_2_ == "collision_camera037" and not Scenario.ReadFromBlackboard("GammaIntroCutscenePlayed", false) then
     s025_area2b.LaunchFirstTimeGammaPresentation()
   end
   Scenario.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_)

--- a/open_samus_returns_rando/files/levels/s030_area3.lua
+++ b/open_samus_returns_rando/files/levels/s030_area3.lua
@@ -124,8 +124,7 @@ function s030_area3.OnGamma_005_Intro_C_Generated(_ARG_0_, _ARG_1_)
   s030_area3.OnGamma_005_C_Generated(_ARG_0_, _ARG_1_)
 end
 function s030_area3.OnGamma_005_C_Generated(_ARG_0_, _ARG_1_)
-  -- TODO: No idea if this is the right one (multi-room gamma)
-  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_005_C")
+  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_005_C", true)
   if _ARG_1_ ~= nil then
     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door015")
     _ARG_1_.AI.bPlaceholder = false

--- a/open_samus_returns_rando/files/levels/s033_area3b.lua
+++ b/open_samus_returns_rando/files/levels/s033_area3b.lua
@@ -404,8 +404,7 @@ function s033_area3b.OnGamma_004_Intro_B_Generated(_ARG_0_, _ARG_1_)
   s033_area3b.OnGamma_004_B_Generated(_ARG_0_, _ARG_1_)
 end
 function s033_area3b.OnGamma_004_B_Generated(_ARG_0_, _ARG_1_)
-  -- TODO: No idea if this is the right one (multi-room gamma)
-  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_004_B")
+  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_004_B", true)
   if _ARG_1_ ~= nil then
     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door014")
     _ARG_1_.AI.bPlaceholder = false

--- a/open_samus_returns_rando/files/levels/s036_area3c.lua
+++ b/open_samus_returns_rando/files/levels/s036_area3c.lua
@@ -224,8 +224,7 @@ function s036_area3c.OnEnter_SetCheckpoint_001_Gamma_007()
   Game.SetBossCheckPointNames("ST_SG_Gamma_007", "ST_SG_Gamma_007", "SG_Gamma_007_A", "SG_Gamma_007_B", "SG_Gamma_007_C")
 end
 function s036_area3c.OnGamma_007_A_Generated(_ARG_0_, _ARG_1_)
-  -- TODO: No idea if this is the right one (multi-room gamma)
-  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_007_A")
+  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_007_A", true)
   if _ARG_1_ ~= nil then
     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door006")
     _ARG_1_.AI.bPlaceholder = false

--- a/open_samus_returns_rando/files/levels/s040_area4.lua
+++ b/open_samus_returns_rando/files/levels/s040_area4.lua
@@ -55,8 +55,7 @@ function s040_area4.OnGamma_001_Intro_A_Generated(_ARG_0_, _ARG_1_)
   s040_area4.OnGamma_001_A_Generated(_ARG_0_, _ARG_1_)
 end
 function s040_area4.OnGamma_001_A_Generated(_ARG_0_, _ARG_1_)
-  -- TODO: No idea if this is the right one (multi-room gamma)
-  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_001_A")
+  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_001_A", true)
   if _ARG_1_ ~= nil then
     -- _ARG_1_.AI:AddBossDoor("Door011")
     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door004")

--- a/open_samus_returns_rando/files/levels/s050_area5.lua
+++ b/open_samus_returns_rando/files/levels/s050_area5.lua
@@ -126,8 +126,7 @@ function s050_area5.OnGamma_002_Intro_A_Generated(_ARG_0_, _ARG_1_)
   s050_area5.OnGamma_002_A_Generated(_ARG_0_, _ARG_1_)
 end
 function s050_area5.OnGamma_002_A_Generated(_ARG_0_, _ARG_1_)
-  -- TODO: No idea if this is the right one (multi-room gamma)
-  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_002_A")
+  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_002_A", true)
   if _ARG_1_ ~= nil then
     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door014")
     _ARG_1_.AI.bPlaceholder = false

--- a/open_samus_returns_rando/files/levels/s070_area7.lua
+++ b/open_samus_returns_rando/files/levels/s070_area7.lua
@@ -805,7 +805,7 @@ function s070_area7.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_)
       Game.SetCameraEnemy("manicminerbot")
       s070_area7.LaunchManicMinerBotIntroCutscene()
     end
-  elseif (_ARG_0_ == "collision_camera_047" or _ARG_2_ == "collision_camera_046") and (_ARG_2_ == "collision_camera_037" or _ARG_2_ == "collision_camera_046") and _ARG_3_ == "Omega_Enabled" and not Scenario.ReadFromBlackboard("OmegaIntroCutscenePlayed", false) then
+  elseif _ARG_2_ == "collision_camera_037" and _ARG_3_ == "Omega_Enabled" and not Scenario.ReadFromBlackboard("OmegaIntroCutscenePlayed", false) then
     s070_area7.LaunchFirstTimeOmegaPresentation()
   end
   if _ARG_2_ == "collision_camera_037" and _ARG_3_ == "Omega_Enabled" and not Scenario.ReadFromBlackboard("entity_SG_Omega_001_deaths", false) then

--- a/open_samus_returns_rando/files/templates/metroid_template.lua
+++ b/open_samus_returns_rando/files/templates/metroid_template.lua
@@ -32,6 +32,7 @@ function Metroid.RemoveMetroid(_ARG_0_)
                 Metroid.Pickups[scenario][spawnGroupName].OnPickedUp ~= nil then
             Metroid.Pickups[scenario][spawnGroupName].OnPickedUp()
         end
+        Game.SetInGameMusicState("RELAX")
     else
         GUI.LaunchMessage("Oops 2", "Metroid.Dummy", "")
     end

--- a/open_samus_returns_rando/files/templates/metroid_template.lua
+++ b/open_samus_returns_rando/files/templates/metroid_template.lua
@@ -7,10 +7,10 @@ function Metroid.RemoveMetroid(_ARG_0_)
     if spawnGroupName ~= nil then
         -- GUI.LaunchMessage(spawnGroupName, "Metroid.Dummy", "")
 
-        local spawnGroup =  Game.GetEntity(spawnGroupName)
+        local spawnGroup = Game.GetEntity(spawnGroupName)
         if spawnGroup ~= nil and spawnGroup.SPAWNGROUP ~= nil then
             spawnGroup.SPAWNGROUP:DisableSpawnGroup()
-        else 
+        else
             GUI.LaunchMessage("Oops 1" .. spawnGroupName, "Metroid.Dummy", "")
             return
         end
@@ -18,7 +18,7 @@ function Metroid.RemoveMetroid(_ARG_0_)
         Scenario.WriteToBlackboard("entity_" .. spawnGroupName .. "_dead", "b", true)
         Scenario.WriteToBlackboard("entity_" .. spawnGroupName .. "_deaths", "i", 1)
         Scenario.WriteToBlackboard("entity_" .. spawnGroupName .. "_enabled", "b", false)
-        
+
         local count = Game.GetItemAmount(Game.GetPlayerName(), "ITEM_METROID_COUNT") + 1
         Game.SetItemAmount(Game.GetPlayerName(), "ITEM_METROID_COUNT", count)
         Game.IncrementMetroidTotalCount(0)
@@ -27,10 +27,10 @@ function Metroid.RemoveMetroid(_ARG_0_)
 
         local scenario = Scenario.CurrentScenarioID
         if scenario ~= nil and Metroid.Pickups ~= nil and
-            Metroid.Pickups[scenario] ~= nil and 
+            Metroid.Pickups[scenario] ~= nil and
             Metroid.Pickups[scenario][spawnGroupName] ~= nil and
             Metroid.Pickups[scenario][spawnGroupName].OnPickedUp ~= nil then
-                Metroid.Pickups[scenario][spawnGroupName].OnPickedUp()
+            Metroid.Pickups[scenario][spawnGroupName].OnPickedUp()
         end
     else
         GUI.LaunchMessage("Oops 2", "Metroid.Dummy", "")

--- a/open_samus_returns_rando/files/templates/metroid_template.lua
+++ b/open_samus_returns_rando/files/templates/metroid_template.lua
@@ -40,8 +40,8 @@ function Metroid.RemoveMetroid(_ARG_0_)
                 Metroid.DisableSpawnGroup(otherSpawnGroupName)
             end
             local allDead = "Arena_" .. string.sub(spawnGroupName, 4, -3) .. "_AllDead"
-            Game.AddSF(4.0, "Metroid.DelayedDelete", "s", spawnGroupName)
             Scenario.WriteToBlackboard(allDead, "b", true)
+            Game.AddSF(4.0, "Metroid.DelayedDelete", "s", spawnGroupName)
         -- disable single arena metroid
         else
             Metroid.DisableSpawnGroup(spawnGroupName)

--- a/open_samus_returns_rando/files/templates/metroid_template.lua
+++ b/open_samus_returns_rando/files/templates/metroid_template.lua
@@ -14,8 +14,17 @@ end
 
 function Metroid.DelayedDelete(spawnGroupName)
     Game.DeleteEntity(spawnGroupName)
-    -- TODO: Generalise the following line
-    CurrentScenario.OnEnter_Gamma_004_Dead()
+    if spawnGroupName == "SG_Gamma_001_A" then
+        CurrentScenario.OnEnter_Gamma_001_Dead()
+    elseif spawnGroupName == "SG_Gamma_002_A" then
+        CurrentScenario.OnEnter_Gamma_002_Dead()
+    elseif spawnGroupName == "SG_Gamma_004_B" then
+        CurrentScenario.OnEnter_Gamma_004_Dead()
+    elseif spawnGroupName == "SG_Gamma_005_C" then
+        CurrentScenario.OnEnter_Gamma_005_Dead()
+    elseif spawnGroupName == "SG_Gamma_007_A" then
+        CurrentScenario.OnEnter_Gamma_007_Dead()
+    end
     -- TODO: Is the name allowed to be random?
     Game.SaveGame("checkpoint", "AfterNewAbilityAcquired", "", true)
 end
@@ -31,14 +40,11 @@ function Metroid.RemoveMetroid(_ARG_0_)
                 Metroid.DisableSpawnGroup(otherSpawnGroupName)
             end
             local allDead = "Arena_" .. string.sub(spawnGroupName, 4, -3) .. "_AllDead"
+            Game.AddSF(4.0, "Metroid.DelayedDelete", "s", spawnGroupName)
             Scenario.WriteToBlackboard(allDead, "b", true)
         -- disable single arena metroid
         else
             Metroid.DisableSpawnGroup(spawnGroupName)
-        end
-
-        if CurrentScenario.isMultiGamma then
-            Game.AddSF(5.0, "Metroid.DelayedDelete", "s", spawnGroupName)
         end
 
         local count = Game.GetItemAmount(Game.GetPlayerName(), "ITEM_METROID_COUNT") + 1

--- a/open_samus_returns_rando/files/templates/metroid_template.lua
+++ b/open_samus_returns_rando/files/templates/metroid_template.lua
@@ -27,9 +27,9 @@ function Metroid.RemoveMetroid(_ARG_0_)
 
         local scenario = Scenario.CurrentScenarioID
         if scenario ~= nil and Metroid.Pickups ~= nil and
-            Metroid.Pickups[scenario] ~= nil and
-            Metroid.Pickups[scenario][spawnGroupName] ~= nil and
-            Metroid.Pickups[scenario][spawnGroupName].OnPickedUp ~= nil then
+                Metroid.Pickups[scenario] ~= nil and
+                Metroid.Pickups[scenario][spawnGroupName] ~= nil and
+                Metroid.Pickups[scenario][spawnGroupName].OnPickedUp ~= nil then
             Metroid.Pickups[scenario][spawnGroupName].OnPickedUp()
         end
     else

--- a/open_samus_returns_rando/files/templates/metroid_template.lua
+++ b/open_samus_returns_rando/files/templates/metroid_template.lua
@@ -2,28 +2,39 @@ Metroid = {}
 function Metroid.Dummy()
 end
 
-function Metroid.RemoveMetroid(_ARG_0_)
-    local spawnGroupName = CurrentScenario.currentMetroidSpawngroup
-    if spawnGroupName ~= nil then
-        -- GUI.LaunchMessage(spawnGroupName, "Metroid.Dummy", "")
-
-        local spawnGroup = Game.GetEntity(spawnGroupName)
-        if spawnGroup ~= nil and spawnGroup.SPAWNGROUP ~= nil then
-            spawnGroup.SPAWNGROUP:DisableSpawnGroup()
-        else
-            GUI.LaunchMessage("Oops 1" .. spawnGroupName, "Metroid.Dummy", "")
-            return
-        end
-
+function Metroid.DisableSpawnGroup(spawnGroupName)
+    local spawnGroup = Game.GetEntity(spawnGroupName)
+    if spawnGroup ~= nil and spawnGroup.SPAWNGROUP ~= nil then
+        spawnGroup.SPAWNGROUP:DisableSpawnGroup()
         Scenario.WriteToBlackboard("entity_" .. spawnGroupName .. "_dead", "b", true)
         Scenario.WriteToBlackboard("entity_" .. spawnGroupName .. "_deaths", "i", 1)
         Scenario.WriteToBlackboard("entity_" .. spawnGroupName .. "_enabled", "b", false)
+    end
+end
+
+function Metroid.RemoveMetroid(_ARG_0_)
+    local spawnGroupName = CurrentScenario.currentMetroidSpawngroup
+    if spawnGroupName ~= nil then
+        -- disable all spawn groups in case of multi arena gamma
+        if CurrentScenario.isMultiGamma then
+            local endingLetters = {"A", "B", "C"}
+            for index, letter in pairs(endingLetters) do
+                local otherSpawnGroupName = string.sub(spawnGroupName, 0, -2) .. letter
+                Metroid.DisableSpawnGroup(otherSpawnGroupName)
+            end
+            local allDead = "Arena_" .. string.sub(spawnGroupName, 4, -3) .. "_AllDead"
+            Scenario.WriteToBlackboard(allDead, "b", true)
+        -- disable single arena metroid
+        else
+            Metroid.DisableSpawnGroup(spawnGroupName)
+        end
 
         local count = Game.GetItemAmount(Game.GetPlayerName(), "ITEM_METROID_COUNT") + 1
         Game.SetItemAmount(Game.GetPlayerName(), "ITEM_METROID_COUNT", count)
         Game.IncrementMetroidTotalCount(0)
 
         CurrentScenario.currentMetroidSpawngroup = nil
+        CurrentScenario.isMultiGamma = nil
 
         local scenario = Scenario.CurrentScenarioID
         if scenario ~= nil and Metroid.Pickups ~= nil and

--- a/open_samus_returns_rando/files/templates/metroid_template.lua
+++ b/open_samus_returns_rando/files/templates/metroid_template.lua
@@ -12,6 +12,14 @@ function Metroid.DisableSpawnGroup(spawnGroupName)
     end
 end
 
+function Metroid.DelayedDelete(spawnGroupName)
+    Game.DeleteEntity(spawnGroupName)
+    -- TODO: Generalise the following line
+    CurrentScenario.OnEnter_Gamma_004_Dead()
+    -- TODO: Is the name allowed to be random?
+    Game.SaveGame("checkpoint", "AfterNewAbilityAcquired", "", true)
+end
+
 function Metroid.RemoveMetroid(_ARG_0_)
     local spawnGroupName = CurrentScenario.currentMetroidSpawngroup
     if spawnGroupName ~= nil then
@@ -29,12 +37,13 @@ function Metroid.RemoveMetroid(_ARG_0_)
             Metroid.DisableSpawnGroup(spawnGroupName)
         end
 
+        if CurrentScenario.isMultiGamma then
+            Game.AddSF(5.0, "Metroid.DelayedDelete", "s", spawnGroupName)
+        end
+
         local count = Game.GetItemAmount(Game.GetPlayerName(), "ITEM_METROID_COUNT") + 1
         Game.SetItemAmount(Game.GetPlayerName(), "ITEM_METROID_COUNT", count)
         Game.IncrementMetroidTotalCount(0)
-
-        CurrentScenario.currentMetroidSpawngroup = nil
-        CurrentScenario.isMultiGamma = nil
 
         local scenario = Scenario.CurrentScenarioID
         if scenario ~= nil and Metroid.Pickups ~= nil and
@@ -44,9 +53,15 @@ function Metroid.RemoveMetroid(_ARG_0_)
             Metroid.Pickups[scenario][spawnGroupName].OnPickedUp()
         end
         Game.SetInGameMusicState("RELAX")
+        if not CurrentScenario.isMultiGamma then
+        -- TODO: Is the name allowed to be random?
+            Game.SaveGame("checkpoint", "AfterNewAbilityAcquired", "", true)
+        end
     else
         GUI.LaunchMessage("Oops 2", "Metroid.Dummy", "")
     end
+    CurrentScenario.currentMetroidSpawngroup = nil
+    CurrentScenario.isMultiGamma = nil
 end
 
 Metroid.Pickups = TEMPLATE("mapping")

--- a/open_samus_returns_rando/files/templates/metroid_template.lua
+++ b/open_samus_returns_rando/files/templates/metroid_template.lua
@@ -25,8 +25,7 @@ function Metroid.DelayedDelete(spawnGroupName)
     elseif spawnGroupName == "SG_Gamma_007_A" then
         CurrentScenario.OnEnter_Gamma_007_Dead()
     end
-    -- TODO: Is the name allowed to be random?
-    Game.SaveGame("checkpoint", "AfterNewAbilityAcquired", "", true)
+    -- TODO: Add proper checkpoints
 end
 
 function Metroid.RemoveMetroid(_ARG_0_)
@@ -60,7 +59,6 @@ function Metroid.RemoveMetroid(_ARG_0_)
         end
         Game.SetInGameMusicState("RELAX")
         if not CurrentScenario.isMultiGamma then
-        -- TODO: Is the name allowed to be random?
             Game.SaveGame("checkpoint", "AfterNewAbilityAcquired", "", true)
         end
     else

--- a/open_samus_returns_rando/specific_patches/metroid_patches.py
+++ b/open_samus_returns_rando/specific_patches/metroid_patches.py
@@ -69,6 +69,11 @@ def patch_metroids(editor: PatcherEditor):
         metroid_bmsad = editor.get_parsed_asset(metroid_file, type_hint=Bmsad)
         action_set_anim = metroid_bmsad.action_sets[0].raw["animations"][death_index]
         action_set_anim["events0"][function_index]["args"][601445949]["value"] = "RemoveMetroid"
+        if metroid_file in {
+            "actors/characters/gamma/charclasses/gamma.bmsad",
+            "actors/characters/gammaevolved/charclasses/gammaevolved.bmsad"
+            }:
+            metroid_bmsad.action_sets[0].raw["animations"][2]["events0"][function_index]["args"][601445949]["value"] = "RemoveMetroid"
 
         drop_component = metroid_bmsad.raw["components"]["DROP"]
         # weird case where some fields are defined two times

--- a/open_samus_returns_rando/specific_patches/metroid_patches.py
+++ b/open_samus_returns_rando/specific_patches/metroid_patches.py
@@ -10,70 +10,36 @@ from open_samus_returns_rando.patcher_editor import PatcherEditor
 LOG = logging.getLogger("metroid_patches")
 
 def patch_metroids(editor: PatcherEditor):
-    METROID_DICTS = [
-        {
-            "file": "actors/characters/alpha/charclasses/alpha.bmsad",
-            "death_index": 22,
-            "function_index": 3
-        },
-        {
-            "file": "actors/characters/alphaevolved/charclasses/alphaevolved.bmsad",
-            "death_index": 22,
-            "function_index": 3
-        },
-        {
-            "file": "actors/characters/alphanewborn/charclasses/alphanewborn.bmsad",
-            "death_index": 22,
-            "function_index": 3
-        },
-        {
-            "file": "actors/characters/gamma/charclasses/gamma.bmsad",
-            "death_index": 54,
-            "function_index": 16
-        },
-        {
-            "file": "actors/characters/gammaevolved/charclasses/gammaevolved.bmsad",
-            "death_index": 54,
-            "function_index": 16
-        },
-        {
-            "file": "actors/characters/omega/charclasses/omega.bmsad",
-            "death_index": 74,
-            "function_index": 13
-        },
-        {
-            "file": "actors/characters/omegaevolved/charclasses/omegaevolved.bmsad",
-            "death_index": 74,
-            "function_index": 13
-        },
-        {
-            "file": "actors/characters/zeta/charclasses/zeta.bmsad",
-            "death_index": 56,
-            "function_index": 9
-        },
-        {
-            "file": "actors/characters/zetaevolved/charclasses/zetaevolved.bmsad",
-            "death_index": 56,
-            "function_index": 9
-        },
+    METROID_FILES = [
+        "actors/characters/alpha/charclasses/alpha.bmsad",
+        "actors/characters/alphaevolved/charclasses/alphaevolved.bmsad",
+        "actors/characters/alphanewborn/charclasses/alphanewborn.bmsad",
+        "actors/characters/gamma/charclasses/gamma.bmsad",
+        "actors/characters/gammaevolved/charclasses/gammaevolved.bmsad",
+        "actors/characters/omega/charclasses/omega.bmsad",
+        "actors/characters/omegaevolved/charclasses/omegaevolved.bmsad",
+        "actors/characters/zeta/charclasses/zeta.bmsad",
+        "actors/characters/zetaevolved/charclasses/zetaevolved.bmsad",
     ]
 
     for area_name in ALL_AREAS:
         editor.ensure_present_in_scenario(area_name, "actors/scripts/metroid.lc")
 
-    for metroid_dict in METROID_DICTS:
-        metroid_file = metroid_dict["file"]
-        death_index = metroid_dict["death_index"]
-        function_index = metroid_dict["function_index"]
-
+    for metroid_file in METROID_FILES:
         metroid_bmsad = editor.get_parsed_asset(metroid_file, type_hint=Bmsad)
-        action_set_anim = metroid_bmsad.action_sets[0].raw["animations"][death_index]
-        action_set_anim["events0"][function_index]["args"][601445949]["value"] = "RemoveMetroid"
-        if metroid_file in {
-            "actors/characters/gamma/charclasses/gamma.bmsad",
-            "actors/characters/gammaevolved/charclasses/gammaevolved.bmsad"
-            }:
-            metroid_bmsad.action_sets[0].raw["animations"][2]["events0"][function_index]["args"][601445949]["value"] = "RemoveMetroid"
+        animations = metroid_bmsad.action_sets[0].raw["animations"]
+
+        for animation in animations:
+            events0 = animation["events0"]
+            death_callbacks = [
+                item
+                for events in events0
+                for magic_number, item in events["args"].items()
+                # arguments with this number  defines the function to call
+                if magic_number == 601445949
+            ]
+            for death_callback in death_callbacks:
+                death_callback["value"] = "RemoveMetroid"
 
         drop_component = metroid_bmsad.raw["components"]["DROP"]
         # weird case where some fields are defined two times
@@ -91,7 +57,7 @@ def patch_metroids(editor: PatcherEditor):
             ai_component["fields"]["bRemovePlayerInputOnDeath"]["value"] = False
             ai_component["fields"]["bSetPlayerInvulnerableWithReactionOnDeath"]["value"] = False
 
-
+        # script component defines in which lua file the function names from "args" can be found
         script_component = metroid_bmsad.raw["components"]["SCRIPT"]
         script_component["functions"][0]["params"]["Param1"]["value"] = "actors/scripts/metroid.lc"
         script_component["functions"][0]["params"]["Param2"]["value"] = "Metroid"

--- a/tests/test_files/metroid_2b.json
+++ b/tests/test_files/metroid_2b.json
@@ -1,0 +1,4049 @@
+{
+    "starting_location": {
+        "scenario": "s025_area2b",
+        "actor": "SpawnGroup019"
+    },
+    "starting_items": {
+        "ITEM_WEAPON_MISSILE_MAX": 50,
+        "ITEM_WEAPON_POWER_BOMB": 1,
+        "ITEM_WEAPON_POWER_BOMB_MAX": 15,
+        "ITEM_WEAPON_SUPER_MISSILE": 1,
+        "ITEM_WEAPON_SUPER_MISSILE_MAX": 15,
+        "ITEM_WEAPON_WAVE_BEAM": 1,
+        "ITEM_WEAPON_CHARGE_BEAM": 1,
+        "ITEM_WEAPON_SPAZER_BEAM": 1,
+        "ITEM_GRAVITY_SUIT": 1,
+        "ITEM_HIGH_JUMP_BOOTS": 1,
+        "ITEM_SPACE_JUMP": 1,
+        "ITEM_SPRING_BALL": 1,
+        "ITEM_WEAPON_GRAPPLE_BEAM": 1,
+        "ITEM_SPECIAL_ENERGY_SCANNING_PULSE": 1,
+        "ITEM_ENERGY_TANKS": 8,
+        "ITEM_MORPH_BALL": 1,
+        "ITEM_SPIDER_BALL": 1,
+        "ITEM_RANDO_DNA_11": 1,
+        "ITEM_RANDO_DNA_12": 1,
+        "ITEM_RANDO_DNA_13": 1,
+        "ITEM_RANDO_DNA_14": 1,
+        "ITEM_RANDO_DNA_15": 1,
+        "ITEM_RANDO_DNA_16": 1,
+        "ITEM_RANDO_DNA_17": 1,
+        "ITEM_RANDO_DNA_18": 1,
+        "ITEM_RANDO_DNA_19": 1,
+        "ITEM_RANDO_DNA_20": 1,
+        "ITEM_RANDO_DNA_21": 1,
+        "ITEM_RANDO_DNA_22": 1,
+        "ITEM_RANDO_DNA_23": 1,
+        "ITEM_RANDO_DNA_24": 1,
+        "ITEM_RANDO_DNA_25": 1,
+        "ITEM_RANDO_DNA_26": 1,
+        "ITEM_RANDO_DNA_27": 1,
+        "ITEM_RANDO_DNA_28": 1,
+        "ITEM_RANDO_DNA_29": 1,
+        "ITEM_RANDO_DNA_30": 1,
+        "ITEM_RANDO_DNA_31": 1,
+        "ITEM_RANDO_DNA_32": 1,
+        "ITEM_RANDO_DNA_33": 1,
+        "ITEM_RANDO_DNA_34": 1,
+        "ITEM_RANDO_DNA_35": 1,
+        "ITEM_RANDO_DNA_36": 1,
+        "ITEM_RANDO_DNA_37": 1,
+        "ITEM_RANDO_DNA_38": 1,
+        "ITEM_RANDO_DNA_39": 1,
+        "ITEM_MAX_LIFE": 99,
+        "ITEM_MAX_SPECIAL_ENERGY": 1000
+    },
+    "pickups": [
+        {
+            "pickup_type": "actor",
+            "caption": "Bomb acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_BOMB",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "powerup_bomb"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "item_energytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_Item_005"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Jump acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_HIGH_JUMP_BOOTS",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_SPACE_JUMP",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_Item_006"
+            },
+            "model": [
+                "powerup_highjumpboots",
+                "powerup_spacejump"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_Item_007"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_Item_008"
+            },
+            "model": [
+                "item_energytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Beam acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_WAVE_BEAM",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_SPAZER_BEAM",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_PLASMA_BEAM",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_Item_010"
+            },
+            "model": [
+                "powerup_wavebeam",
+                "powerup_spazerbeam",
+                "powerup_plasmabeam"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_Item_011"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_Item_012"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_PowerUP_ChargeBeam"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Morph Ball acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MORPH_BALL",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_PowerUP_Morphball"
+            },
+            "model": [
+                "powerup_morphball"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "LE_SpecialAbility_ScanningPulse"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s000_surface",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_Item_005"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_Item_006"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Lightning Armor acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SPECIAL_ENERGY_ENERGY_SHIELD",
+                        "quantity": 1
+                    },
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 150
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_Item_008"
+            },
+            "model": [
+                "powerup_energyshield"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_Item_011"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_Item_013"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Spider Ball acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SPIDER_BALL",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_Item_014"
+            },
+            "model": [
+                "powerup_spiderball"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_Item_016"
+            },
+            "model": [
+                "item_powerbombtank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_Item_017"
+            },
+            "model": [
+                "item_powerbombtank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_PowerUp_Bomb"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Charge Beam acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_CHARGE_BEAM",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_PowerUp_IceBeam"
+            },
+            "model": [
+                "powerup_chargebeam"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "LE_PowerUp_SpiderBall"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Main Power Bomb acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_POWER_BOMB",
+                        "quantity": 1
+                    },
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 5
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "powerup_powerbomb"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "HiddenPowerup002"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s010_area1",
+                "actor": "HiddenPowerup003"
+            },
+            "model": [
+                "item_powerbombtank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_area2",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "item_energytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_area2",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_area2",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_area2",
+                "actor": "LE_Item_005"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_area2",
+                "actor": "LE_Item_006"
+            },
+            "model": [
+                "item_energytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_area2",
+                "actor": "LE_PowerUp_Springball"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_area2",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Phase Drift acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SPECIAL_ENERGY_PHASE_DISPLACEMENT",
+                        "quantity": 1
+                    },
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 150
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s020_area2",
+                "actor": "HiddenPowerup002"
+            },
+            "model": [
+                "powerup_phasedisplacement"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Grapple Beam acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_GRAPPLE_BEAM",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s025_area2b",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "powerup_grapplebeam"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s025_area2b",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s025_area2b",
+                "actor": "LE_Item_005"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Beam Burst acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SPECIAL_ENERGY_ENERGY_WAVE",
+                        "quantity": 1
+                    },
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 150
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s025_area2b",
+                "actor": "LE_Item_006"
+            },
+            "model": [
+                "powerup_energywave"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s025_area2b",
+                "actor": "LE_PowerUp_HighJumpBoots"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s025_area2b",
+                "actor": "LE_PowerUp_VariaSuite"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s025_area2b",
+                "actor": "LE_PowerUp_WaveBeam"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s025_area2b",
+                "actor": "HP_Item_001"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s025_area2b",
+                "actor": "HP_Item_002"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s028_area2c",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Beam acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_WAVE_BEAM",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_SPAZER_BEAM",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_PLASMA_BEAM",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s028_area2c",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "powerup_wavebeam",
+                "powerup_spazerbeam",
+                "powerup_plasmabeam"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s028_area2c",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s028_area2c",
+                "actor": "LE_Item_005"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Jump acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_HIGH_JUMP_BOOTS",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_SPACE_JUMP",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s028_area2c",
+                "actor": "LE_SpecialAbility_EnergyShield"
+            },
+            "model": [
+                "powerup_highjumpboots",
+                "powerup_spacejump"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s028_area2c",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_area3",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_area3",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_area3",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_area3",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Beam acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_WAVE_BEAM",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_SPAZER_BEAM",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_PLASMA_BEAM",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_area3",
+                "actor": "LE_Item_005"
+            },
+            "model": [
+                "powerup_wavebeam",
+                "powerup_spazerbeam",
+                "powerup_plasmabeam"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_area3",
+                "actor": "LE_PowerUp_GrappleBeam"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_area3",
+                "actor": "LE_SpecialAbility_EnergyWave"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_area3",
+                "actor": "HP_ChozoHologram_002"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Baby Metroid acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_BABY_HATCHLING",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_area3",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s030_area3",
+                "actor": "HiddenPowerup002"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s033_area3b",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s033_area3b",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s033_area3b",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s033_area3b",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s033_area3b",
+                "actor": "LE_Item_007"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s033_area3b",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s033_area3b",
+                "actor": "HiddenPowerup002"
+            },
+            "model": [
+                "item_energytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s033_area3b",
+                "actor": "HiddenPowerup003"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s036_area3c",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s036_area3c",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s036_area3c",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "item_powerbombtank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s036_area3c",
+                "actor": "LE_Item_006"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s036_area3c",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_area4",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Suit acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_VARIA_SUIT",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_GRAVITY_SUIT",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_area4",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "powerup_variasuit",
+                "powerup_gravitysuit"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Spring Ball acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SPRING_BALL",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_area4",
+                "actor": "LE_Item_005"
+            },
+            "model": [
+                "powerup_springball"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_area4",
+                "actor": "LE_Item_006"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_area4",
+                "actor": "LE_Item_007"
+            },
+            "model": [
+                "item_powerbombtank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_area4",
+                "actor": "LE_Item_008"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_area4",
+                "actor": "LE_PowerUp_SpazerBeam"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_area4",
+                "actor": "HP_ChozoHologram_002"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_area4",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_area4",
+                "actor": "HiddenPowerup003"
+            },
+            "model": [
+                "item_powerbombtank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s040_area4",
+                "actor": "HiddenPowerup004"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "LE_Item_005"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "LE_Item_006"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "LE_Item_009"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "LE_Item_010"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "LE_Item_012"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "LE_Item_013"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "LE_PoweUp_SuperMissile"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "LE_PowerUp_SpaceJump"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Progressive Suit acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_VARIA_SUIT",
+                        "quantity": 1
+                    }
+                ],
+                [
+                    {
+                        "item_id": "ITEM_GRAVITY_SUIT",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "powerup_variasuit",
+                "powerup_gravitysuit"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s050_area5",
+                "actor": "HiddenPowerup002"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_area6",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_area6",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_area6",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_area6",
+                "actor": "LE_Item_006"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_area6",
+                "actor": "LE_Item_007"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_area6",
+                "actor": "LE_SpecialAbility_PhaseDisplacement"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_area6",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s060_area6",
+                "actor": "HiddenPowerup002"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s065_area6b",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "item_powerbombtank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s065_area6b",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s065_area6b",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s065_area6b",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s065_area6b",
+                "actor": "LE_Item_005"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s065_area6b",
+                "actor": "LE_Item_006"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s065_area6b",
+                "actor": "LE_Item_007"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s065_area6b",
+                "actor": "LE_PowerUp_ScrewAttack"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s065_area6b",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s067_area6c",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s067_area6c",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s067_area6c",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s067_area6c",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s067_area6c",
+                "actor": "LE_Item_005"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s067_area6c",
+                "actor": "LE_PowerUp_GravitySuite"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s067_area6c",
+                "actor": "LE_PowerUp_PlasmaBeam"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s067_area6c",
+                "actor": "HP_ChozoHologram_001"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s067_area6c",
+                "actor": "HiddenPowerup002"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Screw Attack acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SCREW_ATTACK",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s067_area6c",
+                "actor": "HiddenPowerup003"
+            },
+            "model": [
+                "powerup_screwattack"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_007"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_008"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_009"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_010"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_012"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_013"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_014"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_PowerUp_Powerbomb"
+            },
+            "model": [
+                "item_powerbombtank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_011"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s070_area7",
+                "actor": "LE_Item_015"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "LE_Item_002"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "item_powerbombtank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "LE_Item_008"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "LE_Item_009"
+            },
+            "model": [
+                "item_energytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "LE_Item_010"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "LE_Item_011"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "LE_Item_012"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "LE_Item_013"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "HiddenPowerup002"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s090_area9",
+                "actor": "HiddenPowerup003"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Item_001"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Item_003"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Item_004"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Item_005"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Item_007"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Item_008"
+            },
+            "model": [
+                "item_powerbombtank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Item_009"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Item_010"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Item_011"
+            },
+            "model": [
+                "item_energytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Item_012"
+            },
+            "model": [
+                "item_senergytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Item_013"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Item_014"
+            },
+            "model": [
+                "item_energytank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "HiddenPowerup001"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "HiddenPowerup002"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s110_surfaceb",
+                "actor": "LE_Item_013"
+            },
+            "model": [
+                "item_missiletank"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s110_surfaceb",
+                "actor": "HiddenPowerup002"
+            },
+            "model": [
+                "itemsphere"
+            ]
+        },
+        {
+            "pickup_type": "actor",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "pickup_actor": {
+                "scenario": "s100_area10",
+                "actor": "LE_Baby_Hatchling"
+            },
+            "model": [
+                "item_supermissiletank"
+            ]
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Aeion Tank acquired.\nAeion Gauge expanded.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_MAX_SPECIAL_ENERGY",
+                        "quantity": 50
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s000_surface",
+                "spawngroup": "SG_Alpha_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s010_area1",
+                "spawngroup": "SG_Alpha_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Metroid DNA 3 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_DNA_3",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s010_area1",
+                "spawngroup": "SG_Alpha_002"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Metroid DNA 9 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_DNA_9",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s010_area1",
+                "spawngroup": "SG_Alpha_003"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s010_area1",
+                "spawngroup": "SG_Alpha_004"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s020_area2",
+                "spawngroup": "SG_Alpha_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s028_area2c",
+                "spawngroup": "SG_Alpha_002"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s020_area2",
+                "spawngroup": "SG_Alpha_003"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Super Missile Launcher acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_SUPER_MISSILE",
+                        "quantity": 1
+                    },
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 5
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s020_area2",
+                "spawngroup": "SG_Alpha_004"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s020_area2",
+                "spawngroup": "SG_Alpha_005"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Metroid DNA 1 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_DNA_1",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s020_area2",
+                "spawngroup": "SG_Alpha_006"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s020_area2",
+                "spawngroup": "SG_Alpha_007"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Ice Beam acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_ICE_BEAM",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s036_area3c",
+                "spawngroup": "SG_Alpha_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s033_area3b",
+                "spawngroup": "SG_Alpha_002"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s033_area3b",
+                "spawngroup": "SG_Alpha_003"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Metroid DNA 8 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_DNA_8",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s040_area4",
+                "spawngroup": "SG_Alpha_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s060_area6",
+                "spawngroup": "SG_Alpha_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Metroid DNA 10 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_DNA_10",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s025_area2b",
+                "spawngroup": "SG_Gamma_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s033_area3b",
+                "spawngroup": "SG_Gamma_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s033_area3b",
+                "spawngroup": "SG_Gamma_002"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s033_area3b",
+                "spawngroup": "SG_Gamma_003"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s033_area3b",
+                "spawngroup": "SG_Gamma_004_B"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s030_area3",
+                "spawngroup": "SG_Gamma_005_C"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s036_area3c",
+                "spawngroup": "SG_Gamma_006"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Metroid DNA 7 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_DNA_7",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s036_area3c",
+                "spawngroup": "SG_Gamma_007_A"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s040_area4",
+                "spawngroup": "SG_Gamma_001_A"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Metroid DNA 5 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_DNA_5",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s050_area5",
+                "spawngroup": "SG_Gamma_002_A"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Energy Tank acquired.\nEnergy capacity increased by 100.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_ENERGY_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s067_area6c",
+                "spawngroup": "SG_Gamma_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Nothing acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_NONE",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s065_area6b",
+                "spawngroup": "SG_Gamma_002"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Metroid DNA 10 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_DNA_10",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s065_area6b",
+                "spawngroup": "SG_Gamma_003"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Metroid DNA 4 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_DNA_4",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s060_area6",
+                "spawngroup": "SG_Gamma_004"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s050_area5",
+                "spawngroup": "SG_Zeta_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Metroid DNA 6 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_DNA_6",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s065_area6b",
+                "spawngroup": "SG_Zeta_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Power Bomb Tank acquired.\nPower Bomb capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_POWER_BOMB_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s067_area6c",
+                "spawngroup": "SG_Zeta_002"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s070_area7",
+                "spawngroup": "SG_Zeta_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Super Missile Tank acquired.\nSuper Missile capacity increased by 1.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_SUPER_MISSILE_TANKS",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s070_area7",
+                "spawngroup": "SG_Omega_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Metroid DNA 2 acquired.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_RANDO_DNA_2",
+                        "quantity": 1
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s090_area9",
+                "spawngroup": "SG_Omega_001"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s090_area9",
+                "spawngroup": "SG_Omega_002"
+            }
+        },
+        {
+            "pickup_type": "metroid",
+            "caption": "Missile Tank acquired.\nMissile capacity increased by 3.",
+            "resources": [
+                [
+                    {
+                        "item_id": "ITEM_WEAPON_MISSILE_MAX",
+                        "quantity": 3
+                    }
+                ]
+            ],
+            "metroid_callback": {
+                "scenario": "s090_area9",
+                "spawngroup": "SG_Omega_003"
+            }
+        }
+    ],
+    "energy_per_tank": 100,
+    "game_patches": {
+        "nerf_power_bombs": true,
+        "nerf_super_missiles": false,
+        "remove_elevator_grapple_blocks": true,
+        "remove_grapple_block_area3_interior_shortcut": true,
+        "patch_surface_crumbles": true,
+        "patch_area1_crumbles": true
+    }
+}

--- a/tests/test_files/metroid_2b.json
+++ b/tests/test_files/metroid_2b.json
@@ -1,7 +1,7 @@
 {
     "starting_location": {
-        "scenario": "s025_area2b",
-        "actor": "SpawnGroup019"
+        "scenario": "s033_area3b",
+        "actor": "SP_MoheekWall_001"
     },
     "starting_items": {
         "ITEM_WEAPON_MISSILE_MAX": 50,
@@ -12,6 +12,7 @@
         "ITEM_WEAPON_WAVE_BEAM": 1,
         "ITEM_WEAPON_CHARGE_BEAM": 1,
         "ITEM_WEAPON_SPAZER_BEAM": 1,
+        "ITEM_VARIA_SUIT": 1,
         "ITEM_GRAVITY_SUIT": 1,
         "ITEM_HIGH_JUMP_BOOTS": 1,
         "ITEM_SPACE_JUMP": 1,


### PR DESCRIPTION
- Ensures the Gamma in area2b always spawns regardless of entrance
- Ensures the Omega in area7 always spawns regardless of entrance
- Fixes Metroid radars not ending
- Fixes #135