### PR TITLE
Add option to traverse Area 8 backwards

### DIFF
--- a/open_samus_returns_rando/files/schema.json
+++ b/open_samus_returns_rando/files/schema.json
@@ -167,6 +167,11 @@
                     "type": "boolean",
                     "description": "Changes the Crumble blocks leaving Area 1 to be Power Beam blocks.",
                     "default": true
+                },
+                "reverse_area8": {
+                    "type": "boolean",
+                    "description": "Removes the wall blocking access to the Baby, allowing access into Area 8 from Surface West.",
+                    "default": false
                 }
             },
             "additionalProperties": false
@@ -295,6 +300,8 @@
                 "ITEM_MAX_LIFE",
                 "ITEM_MAX_SPECIAL_ENERGY",
                 "ITEM_WEAPON_MISSILE_MAX",
+                "ITEM_WEAPON_SUPER_MISSILE_MAX",
+                "ITEM_WEAPON_POWER_BOMB_MAX",
                 "ITEM_SUPER_MISSILE_TANKS",
                 "ITEM_POWER_BOMB_TANKS",
                 "ITEM_WEAPON_ICE_BEAM",

--- a/open_samus_returns_rando/files/schema.json
+++ b/open_samus_returns_rando/files/schema.json
@@ -170,7 +170,7 @@
                 },
                 "reverse_area8": {
                     "type": "boolean",
-                    "description": "Removes the wall blocking access to the Baby, allowing access into Area 8 from Surface West.",
+                    "description": "Removes the wall between the Queen and Baby, allowing access into Area 8 from Surface West.",
                     "default": false
                 }
             },

--- a/open_samus_returns_rando/specific_patches/game_patches.py
+++ b/open_samus_returns_rando/specific_patches/game_patches.py
@@ -41,6 +41,7 @@ def apply_game_patches(editor: PatcherEditor, configuration: dict):
     # Area patches
     _remove_grapple_blocks(editor, configuration)
     _patch_crumble_blocks(editor, configuration)
+    _patch_reverse_area8(editor, configuration)
 
 
 def _remove_pb_weaknesses(editor: PatcherEditor):
@@ -115,3 +116,10 @@ def _patch_crumble_blocks(editor: PatcherEditor, configuration: dict):
         area1_chozo_seal_crumbles["types"][0]["blocks"][2]["respawn_time"] = 0.0
         area1_chozo_seal_crumbles["types"][0]["blocks"][3]["respawn_time"] = 0.0
         area1_chozo_seal_crumbles["types"][0]["blocks"][4]["respawn_time"] = 0.0
+
+
+def _patch_reverse_area8(editor: PatcherEditor, configuration: dict):
+    if configuration["reverse_area8"]:
+        editor.remove_entity(
+            {"scenario": "s100_area10", "layer": 9, "actor": "LE_ValveQueen"}
+        )


### PR DESCRIPTION
I'm making this an option instead of forced because it has big logical implications of how to travel the planet.