### PR TITLE
Fix invisible progressives

### DIFF
--- a/open_samus_returns_rando/files/levels/s040_area4.lua
+++ b/open_samus_returns_rando/files/levels/s040_area4.lua
@@ -647,3 +647,6 @@ end
 function s040_area4.OnExit_ChangeCamera_023()
   Game.SetCollisionCameraLocked("collision_camera_023_B", false)
 end
+function s040_area4.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_)
+  Scenario.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_)
+end

--- a/open_samus_returns_rando/files/levels/s060_area6.lua
+++ b/open_samus_returns_rando/files/levels/s060_area6.lua
@@ -349,3 +349,7 @@ end
 function s060_area6.OnExit_ChangeCamera_006()
   Game.SetCollisionCameraLocked("collision_camera_006_B", false)
 end
+
+function s060_area6.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_)
+  Scenario.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_)
+end

--- a/open_samus_returns_rando/files/levels/s065_area6b.lua
+++ b/open_samus_returns_rando/files/levels/s065_area6b.lua
@@ -396,3 +396,6 @@ end
 function s065_area6b.OnExit_ChangeCamera_002()
   Game.SetCollisionCameraLocked("collision_camera_002_B", false)
 end
+function s065_area6b.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_)
+  Scenario.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_)
+end

--- a/open_samus_returns_rando/files/levels/s067_area6c.lua
+++ b/open_samus_returns_rando/files/levels/s067_area6c.lua
@@ -418,3 +418,6 @@ function s067_area6c.LaunchSpecialEvent06c()
   end
   Game.DisableTrigger("TG_Event_06c01")
 end
+function s067_area6c.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_)
+  Scenario.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_)
+end


### PR DESCRIPTION
Fixes #45 

We update progressive models `OnSubAreaChange` and I just added the global scenario variant to each scenario specific file. Oversight from me was, that there are scenario specific files which do not declare it at all. Hence they didn't showed up when I just  turned my brain off, searched for `OnSubAreaChange` and copy pasted the line.

This also explains

> Edit: I collected the Screw Attack locked item in Area 5 Exterior and then Progressive Suit (top of the same room) suddenly appeared. Something weird is going on.

because models are also updated if you collect any item which was the only way to make the items visible at all for the missing scenarios.
