### PR TITLE
Fix that aeion energy upgrades are doubled

### DIFF
--- a/open_samus_returns_rando/files/randomizer_powerup.lua
+++ b/open_samus_returns_rando/files/randomizer_powerup.lua
@@ -38,8 +38,8 @@ function RandomizerPowerup.IncreaseItemAmount(item_id, quantity, capacity)
 
     if  item_id == "ITEM_CURRENT_SPECIAL_ENERGY" then
         local specialEnergy = Game.GetPlayer().SPECIALENERGY
-        specialEnergy.fMaxEnergy = capacity + quantity
-        specialEnergy.fEnergy = capacity + quantity
+        specialEnergy.fMaxEnergy = capacity
+        specialEnergy.fEnergy = capacity
     end
 end
 


### PR DESCRIPTION
The used `capacity` variable is already the increased one in the case.