### PR TITLE
Set ammo current value equal to max value on pickup

### DIFF
--- a/open_samus_returns_rando/files/randomizer_powerup.lua
+++ b/open_samus_returns_rando/files/randomizer_powerup.lua
@@ -41,12 +41,12 @@ function RandomizerPowerup.IncreaseItemAmount(item_id, quantity, capacity)
         local specialEnergy = Game.GetPlayer().SPECIALENERGY
         specialEnergy.fMaxEnergy = capacity
         specialEnergy.fEnergy = capacity
-    elseif item_id == "ITEM_WEAPON_MISSILE_MAX" then
-        itemAmount:SetItemAmount("ITEM_WEAPON_MISSILE_CURRENT", item_id)
-    elseif item_id == "ITEM_WEAPON_SUPER_MISSILE_MAX" then
-        itemAmount:SetItemAmount("ITEM_WEAPON_SUPER_MISSILE_CURRENT", item_id)
-    elseif item_id == "ITEM_WEAPON_POWER_BOMB_MAX" then
-        itemAmount:SetItemAmount("ITEM_WEAPON_POWER_BOMB_CURRENT", item_id)
+    elseif item_id == "ITEM_WEAPON_MISSILE_CURRENT" then
+        itemAmount:SetItemAmount(item_id, capacity)
+    elseif item_id == "ITEM_WEAPON_SUPER_MISSILE_CURRENT" then
+        itemAmount:SetItemAmount(item_id, capacity)
+    elseif item_id == "ITEM_WEAPON_POWER_BOMB_CURRENT" then
+        itemAmount:SetItemAmount(item_id, capacity)
     end
 end
 

--- a/open_samus_returns_rando/files/randomizer_powerup.lua
+++ b/open_samus_returns_rando/files/randomizer_powerup.lua
@@ -36,10 +36,17 @@ function RandomizerPowerup.IncreaseItemAmount(item_id, quantity, capacity)
     target = math.max(target, 0)
     RandomizerPowerup.SetItemAmount(item_id, target)
 
-    if  item_id == "ITEM_CURRENT_SPECIAL_ENERGY" then
+    local itemAmount = Game.GetPlayer().INVENTORY
+    if item_id == "ITEM_CURRENT_SPECIAL_ENERGY" then
         local specialEnergy = Game.GetPlayer().SPECIALENERGY
         specialEnergy.fMaxEnergy = capacity
         specialEnergy.fEnergy = capacity
+    elseif item_id == "ITEM_WEAPON_MISSILE_MAX" then
+        itemAmount:SetItemAmount("ITEM_WEAPON_MISSILE_CURRENT", item_id)
+    elseif item_id == "ITEM_WEAPON_SUPER_MISSILE_MAX" then
+        itemAmount:SetItemAmount("ITEM_WEAPON_SUPER_MISSILE_CURRENT", item_id)
+    elseif item_id == "ITEM_WEAPON_POWER_BOMB_MAX" then
+        itemAmount:SetItemAmount("ITEM_WEAPON_POWER_BOMB_CURRENT", item_id)
     end
 end
 
@@ -131,7 +138,9 @@ function RandomizerPowerup.IncreaseAmmo(resource)
 
     local current_id = nil
 
-    if resource.item_id == "ITEM_WEAPON_SUPER_MISSILE_MAX" then
+    if resource.item_id == "ITEM_WEAPON_MISSILE_MAX" then
+        current_id = "ITEM_WEAPON_MISSILE_CURRENT"
+    elseif resource.item_id == "ITEM_WEAPON_SUPER_MISSILE_MAX" then
         current_id = "ITEM_WEAPON_SUPER_MISSILE_CURRENT"
     elseif resource.item_id == "ITEM_WEAPON_POWER_BOMB_MAX" then
         current_id = "ITEM_WEAPON_POWER_BOMB_CURRENT"


### PR DESCRIPTION
- Fixes Missiles not properly increasing current ammo when Missile tanks are collected
- Adds QoL where collecting a tank now updates the current value to match the max value, so low ammo counts are less of an issue