### PR TITLE
Add missing checkpoints for most multi-entrance Metroids

### DIFF
--- a/open_samus_returns_rando/files/levels/s000_surface.lua
+++ b/open_samus_returns_rando/files/levels/s000_surface.lua
@@ -227,6 +227,9 @@ end
 function s000_surface.OnEnter_SetCheckpoint_001_Alpha_001()
   Game.SetBossCheckPointNames("ST_SG_Alpha_001", "ST_SG_Alpha_001_Out", "SG_Alpha_001", "", "")
 end
+function s000_surface.OnEnter_SetCheckpoint_002_Alpha_001()
+  Game.SetBossCheckPointNames("ST_SG_Alpha_001B", "ST_SG_Alpha_001B", "SG_Alpha_001", "", "")
+end
 function s000_surface.OnAlpha_001_Generated(_ARG_0_, _ARG_1_)
   Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Alpha_001")
   if _ARG_1_ ~= nil and _ARG_1_.AI ~= nil then

--- a/open_samus_returns_rando/files/levels/s020_area2.lua
+++ b/open_samus_returns_rando/files/levels/s020_area2.lua
@@ -270,6 +270,9 @@ end
 function s020_area2.OnEnter_SetCheckpoint_001_Alpha_003()
   Game.SetBossCheckPointNames("ST_SG_Alpha_003", "ST_SG_Alpha_003_Out", "SG_Alpha_003", "", "")
 end
+function s020_area2.OnEnter_SetCheckpoint_002_Alpha_003()
+  Game.SetBossCheckPointNames("ST_SG_Alpha_003B", "ST_SG_Alpha_003B_Out", "SG_Alpha_003", "", "")
+end
 function s020_area2.OnAlpha_003_Generated(_ARG_0_, _ARG_1_)
   Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Alpha_003")
   if _ARG_1_ ~= nil and _ARG_1_.AI ~= nil then

--- a/open_samus_returns_rando/files/levels/s025_area2b.lua
+++ b/open_samus_returns_rando/files/levels/s025_area2b.lua
@@ -114,7 +114,7 @@ function s025_area2b.OnEnter_SetCheckpoint_001_Gamma_001()
   Game.SetBossCheckPointNames("ST_SG_Gamma_001", "ST_SG_Gamma_001_Out", "SG_Gamma_001", "", "")
 end
 function s025_area2b.OnEnter_SetCheckpoint_002_Gamma_001()
-  Game.SetBossCheckPointNames("ST_SG_Gamma_001_2", "ST_SG_Gamma_001_2_Out", "SG_Gamma_001", "", "")
+  Game.SetBossCheckPointNames("ST_SG_Gamma_001B", "ST_SG_Gamma_001B_Out", "SG_Gamma_001", "", "")
 end
 function s025_area2b.OnGamma_001_Generated(_ARG_0_, _ARG_1_)
   Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_001")

--- a/open_samus_returns_rando/files/levels/s033_area3b.lua
+++ b/open_samus_returns_rando/files/levels/s033_area3b.lua
@@ -77,6 +77,9 @@ end
 function s033_area3b.OnEnter_SetCheckpoint_001_Alpha_002()
   Game.SetBossCheckPointNames("ST_SG_Alpha_002", "ST_SG_Alpha_002_Out", "SG_Alpha_002", "", "")
 end
+function s033_area3b.OnEnter_SetCheckpoint_002_Alpha_002()
+  Game.SetBossCheckPointNames("ST_SG_Alpha_002B", "ST_SG_Alpha_002B_Out", "SG_Alpha_002", "", "")
+end
 function s033_area3b.OnAlpha_002_Generated(_ARG_0_, _ARG_1_)
   Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Alpha_002")
   if _ARG_1_ ~= nil and _ARG_1_.AI ~= nil then

--- a/open_samus_returns_rando/files/levels/s033_area3b.lua
+++ b/open_samus_returns_rando/files/levels/s033_area3b.lua
@@ -77,9 +77,6 @@ end
 function s033_area3b.OnEnter_SetCheckpoint_001_Alpha_002()
   Game.SetBossCheckPointNames("ST_SG_Alpha_002", "ST_SG_Alpha_002_Out", "SG_Alpha_002", "", "")
 end
-function s033_area3b.OnEnter_SetCheckpoint_002_Alpha_002()
-  Game.SetBossCheckPointNames("ST_SG_Alpha_002B", "ST_SG_Alpha_002B_Out", "SG_Alpha_002", "", "")
-end
 function s033_area3b.OnAlpha_002_Generated(_ARG_0_, _ARG_1_)
   Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Alpha_002")
   if _ARG_1_ ~= nil and _ARG_1_.AI ~= nil then

--- a/open_samus_returns_rando/files/levels/s060_area6.lua
+++ b/open_samus_returns_rando/files/levels/s060_area6.lua
@@ -145,6 +145,9 @@ end
 function s060_area6.OnEnter_SetCheckpoint_001_Alpha_001()
   Game.SetBossCheckPointNames("ST_SG_Alpha_001", "ST_SG_Alpha_001", "SG_Alpha_001", "", "")
 end
+function s060_area6.OnEnter_SetCheckpoint_002_Alpha_001()
+  Game.SetBossCheckPointNames("ST_SG_Alpha_001B", "ST_SG_Alpha_001B", "SG_Alpha_001", "", "")
+end
 function s060_area6.OnAlpha_001_Generated(_ARG_0_, _ARG_1_)
   Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Alpha_001")
   if _ARG_1_ ~= nil and _ARG_1_.AI ~= nil then

--- a/open_samus_returns_rando/files/levels/s060_area6.lua
+++ b/open_samus_returns_rando/files/levels/s060_area6.lua
@@ -146,7 +146,7 @@ function s060_area6.OnEnter_SetCheckpoint_001_Alpha_001()
   Game.SetBossCheckPointNames("ST_SG_Alpha_001", "ST_SG_Alpha_001", "SG_Alpha_001", "", "")
 end
 function s060_area6.OnEnter_SetCheckpoint_002_Alpha_001()
-  Game.SetBossCheckPointNames("ST_SG_Alpha_001B", "ST_SG_Alpha_001B", "SG_Alpha_001", "", "")
+  Game.SetBossCheckPointNames("ST_SG_Alpha_001B", "ST_SG_Alpha_001B_Out", "SG_Alpha_001", "", "")
 end
 function s060_area6.OnAlpha_001_Generated(_ARG_0_, _ARG_1_)
   Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Alpha_001")

--- a/open_samus_returns_rando/files/levels/s070_area7.lua
+++ b/open_samus_returns_rando/files/levels/s070_area7.lua
@@ -176,6 +176,9 @@ end
 function s070_area7.OnEnter_SetCheckpoint_001_Zeta_001()
   Game.SetBossCheckPointNames("ST_SG_Zeta_001", "ST_SG_Zeta_001_Out", "SG_Zeta_001", "", "")
 end
+function s070_area7.OnEnter_SetCheckpoint_002_Zeta_001()
+  Game.SetBossCheckPointNames("ST_SG_Zeta_001B", "ST_SG_Zeta_001B_Out", "SG_Zeta_001", "", "")
+end
 function s070_area7.OnZeta_001_Generated(_ARG_0_, _ARG_1_)
   Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Zeta_001")
   if _ARG_1_ ~= nil then
@@ -195,7 +198,13 @@ function s070_area7.OnEnter_Zeta_001_Dead()
   end
 end
 function s070_area7.OnEnter_SetCheckpoint_001_Omega_001()
-  Game.SetBossCheckPointNames("ST_SG_Omega_001", "ST_SG_Omega_001", "SG_Omega_001", "", "")
+  Game.SetBossCheckPointNames("ST_SG_Omega_001", "ST_SG_Omega_001_Out", "SG_Omega_001", "", "")
+end
+function s070_area7.OnEnter_SetCheckpoint_002_Omega_001()
+  Game.SetBossCheckPointNames("ST_SG_Omega_001B", "ST_SG_Omega_001B_Out", "SG_Omega_001", "", "")
+end
+function s070_area7.OnEnter_SetCheckpoint_003_Omega_001()
+  Game.SetBossCheckPointNames("ST_SG_Omega_001C", "ST_SG_Omega_001C", "SG_Omega_001", "", "")
 end
 function s070_area7.OnOmega_001_Generated(_ARG_0_, _ARG_1_)
   Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Omega_001")

--- a/open_samus_returns_rando/specific_patches/metroid_patches.py
+++ b/open_samus_returns_rando/specific_patches/metroid_patches.py
@@ -82,12 +82,70 @@ def _get_spawnpoint(editor: PatcherEditor):
     return spawnpoint
 
 
-def _create_checkpoint_gamma_2b(editor: PatcherEditor):
+def _create_checkpoint_alpha_surface(editor: PatcherEditor):
+    name_of_scenario = "s000_surface"
+    scenario_surface = editor.get_scenario(name_of_scenario)
+    name_of_trigger = "TG_SetCheckpoint_002_Alpha_001"
+    name_of_spawnpoint = "ST_SG_Alpha_001B"
+
+    trigger = _get_trigger(editor)
+    spawnpoint = _get_spawnpoint(editor)
+
+    editor.copy_actor(
+        name_of_scenario, (-1350.0, -10200.0, 0.0), trigger, name_of_trigger, 0,
+    )
+
+    spawnpoint_actor = editor.copy_actor(
+        name_of_scenario, (-953.0, -9790.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+    )
+
+    scenario_surface.add_actor_to_entity_groups("collision_camera_024", name_of_trigger)
+    scenario_surface.add_actor_to_entity_groups("collision_camera_024", name_of_spawnpoint)
+
+    trigger_actor = scenario_surface.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
+    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Alpha_001"
+
+    spawnpoint_actor["rotation"][1] = -90
+
+
+def _create_checkpoint_alpha_003_area2(editor: PatcherEditor):
+    name_of_scenario = "s020_area2"
+    scenario_2 = editor.get_scenario(name_of_scenario)
+    name_of_trigger = "TG_SetCheckpoint_002_Alpha_003"
+    name_of_spawnpoint = "ST_SG_Alpha_003B"
+    name_of_spawnpoint_out = "ST_SG_Alpha_003B_Out"
+
+    trigger = _get_trigger(editor)
+    spawnpoint = _get_spawnpoint(editor)
+
+    editor.copy_actor(
+        name_of_scenario, (-18550.0, -6100.0, 0.0), trigger, name_of_trigger, 0,
+    )
+
+    editor.copy_actor(
+        name_of_scenario, (-18300.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+    )
+
+    spawnpoint_actor = editor.copy_actor(
+        name_of_scenario, (-18300.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
+    )
+
+    scenario_2.add_actor_to_entity_groups("collision_camera_028", name_of_trigger)
+    scenario_2.add_actor_to_entity_groups("collision_camera_028", name_of_spawnpoint)
+    scenario_2.add_actor_to_entity_groups("collision_camera_028", name_of_spawnpoint_out)
+
+    trigger_actor = scenario_2.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
+    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Alpha_003"
+
+    spawnpoint_actor["rotation"][1] = -90
+
+
+def _create_checkpoint_gamma_area2b(editor: PatcherEditor):
     name_of_scenario = "s025_area2b"
     scenario_2b = editor.get_scenario(name_of_scenario)
     name_of_trigger = "TG_SetCheckpoint_002_Gamma_001"
-    name_of_spawnpoint = "ST_SG_Gamma_001_2"
-    name_of_spawnpoint_out = "ST_SG_Gamma_001_2_Out"
+    name_of_spawnpoint = "ST_SG_Gamma_001B"
+    name_of_spawnpoint_out = "ST_SG_Gamma_001B_Out"
 
     trigger = _get_trigger(editor)
     spawnpoint = _get_spawnpoint(editor)
@@ -113,6 +171,183 @@ def _create_checkpoint_gamma_2b(editor: PatcherEditor):
 
     spawnpoint_actor["rotation"][1] = -90
 
+
+def _create_checkpoint_alpha_002_area3b(editor: PatcherEditor):
+    name_of_scenario = "s033_area3b"
+    scenario_3b = editor.get_scenario(name_of_scenario)
+    name_of_trigger = "TG_SetCheckpoint_002_Alpha_002"
+    name_of_spawnpoint = "ST_SG_Alpha_002B"
+    name_of_spawnpoint_out = "ST_SG_Alpha_002B_Out"
+
+    trigger = _get_trigger(editor)
+    spawnpoint = _get_spawnpoint(editor)
+
+    editor.copy_actor(
+        name_of_scenario, (-17800.0, 800.0, 0.0), trigger, name_of_trigger, 0,
+    )
+
+    editor.copy_actor(
+        name_of_scenario, (-18300.0, 800.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+    )
+
+    spawnpoint_actor = editor.copy_actor(
+        name_of_scenario, (-18300.0, 800.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
+    )
+
+    scenario_3b.add_actor_to_entity_groups("collision_camera_037", name_of_trigger)
+    scenario_3b.add_actor_to_entity_groups("collision_camera_037", name_of_spawnpoint)
+    scenario_3b.add_actor_to_entity_groups("collision_camera_037", name_of_spawnpoint_out)
+
+    trigger_actor = scenario_3b.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
+    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Alpha_002"
+
+    spawnpoint_actor["rotation"][1] = -90
+
+
+def _create_checkpoint_alpha_area6(editor: PatcherEditor):
+    name_of_scenario = "s060_area6"
+    scenario_6 = editor.get_scenario(name_of_scenario)
+    name_of_trigger = "TG_SetCheckpoint_002_Alpha_001"
+    name_of_spawnpoint = "ST_SG_Alpha_001B"
+    name_of_spawnpoint_out = "ST_SG_Alpha_001B_Out"
+
+    trigger = _get_trigger(editor)
+    spawnpoint = _get_spawnpoint(editor)
+
+    editor.copy_actor(
+        name_of_scenario, (3100.0, -6100.0, 0.0), trigger, name_of_trigger, 0,
+    )
+
+    editor.copy_actor(
+        name_of_scenario, (2800.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+    )
+
+    spawnpoint_actor = editor.copy_actor(
+        name_of_scenario, (2800.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
+    )
+
+    scenario_6.add_actor_to_entity_groups("collision_camera_015", name_of_trigger)
+    scenario_6.add_actor_to_entity_groups("collision_camera_015", name_of_spawnpoint)
+    scenario_6.add_actor_to_entity_groups("collision_camera_015", name_of_spawnpoint_out)
+
+    trigger_actor = scenario_6.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
+    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Alpha_001"
+
+    spawnpoint_actor["rotation"][1] = -90
+
+
+def _create_checkpoint_zeta_area7(editor: PatcherEditor):
+    name_of_scenario = "s070_area7"
+    scenario_7 = editor.get_scenario(name_of_scenario)
+    name_of_trigger = "TG_SetCheckpoint_002_Zeta_001"
+    name_of_spawnpoint = "ST_SG_Zeta_001B"
+    name_of_spawnpoint_out = "ST_SG_Zeta_001B_Out"
+
+    trigger = _get_trigger(editor)
+    spawnpoint = _get_spawnpoint(editor)
+
+    editor.copy_actor(
+        name_of_scenario, (6600.0, 7500.0, 0.0), trigger, name_of_trigger, 0,
+    )
+
+    spawnpoint_actor = editor.copy_actor(
+        name_of_scenario, (6900.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+    )
+
+    editor.copy_actor(
+        name_of_scenario, (6900.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
+    )
+
+    scenario_7.add_actor_to_entity_groups("collision_camera_040", name_of_trigger)
+    scenario_7.add_actor_to_entity_groups("collision_camera_040", name_of_spawnpoint)
+    scenario_7.add_actor_to_entity_groups("collision_camera_040", name_of_spawnpoint_out)
+
+    trigger_actor = scenario_7.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
+    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Zeta_001"
+
+    spawnpoint_actor["rotation"][1] = -90
+
+
+def _create_checkpoint_omega_area7_out(editor: PatcherEditor):
+    name_of_scenario = "s070_area7"
+    scenario_7 = editor.get_scenario(name_of_scenario)
+    name_of_spawnpoint_out = "ST_SG_Omega_001_Out"
+
+    spawnpoint = _get_spawnpoint(editor)
+
+    editor.copy_actor(
+        name_of_scenario, (2400.0, 7600.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
+    )
+
+    scenario_7.add_actor_to_entity_groups("collision_camera_047", name_of_spawnpoint_out)
+
+
+def _create_checkpoint_omega_area7_1(editor: PatcherEditor):
+    name_of_scenario = "s070_area7"
+    scenario_7 = editor.get_scenario(name_of_scenario)
+    name_of_trigger = "TG_SetCheckpoint_002_Omega_001"
+    name_of_spawnpoint = "ST_SG_Omega_001B"
+    name_of_spawnpoint_out = "ST_SG_Omega_001B_Out"
+
+    trigger = _get_trigger(editor)
+    spawnpoint = _get_spawnpoint(editor)
+
+    editor.copy_actor(
+        name_of_scenario, (-2000.0, 7500.0, 0.0), trigger, name_of_trigger, 0,
+    )
+
+    editor.copy_actor(
+        name_of_scenario, (-2200.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+    )
+
+    spawnpoint_actor = editor.copy_actor(
+        name_of_scenario, (-2200.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
+    )
+
+    scenario_7.add_actor_to_entity_groups("collision_camera_046", name_of_trigger)
+    scenario_7.add_actor_to_entity_groups("collision_camera_046", name_of_spawnpoint)
+    scenario_7.add_actor_to_entity_groups("collision_camera_046", name_of_spawnpoint_out)
+
+    trigger_actor = scenario_7.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
+    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Omega_001"
+
+    spawnpoint_actor["rotation"][1] = -90
+
+
+def _create_checkpoint_omega_area7_2(editor: PatcherEditor):
+    name_of_scenario = "s070_area7"
+    scenario_7 = editor.get_scenario(name_of_scenario)
+    name_of_trigger = "TG_SetCheckpoint_003_Omega_001"
+    name_of_spawnpoint = "ST_SG_Omega_001C"
+
+    trigger = _get_trigger(editor)
+    spawnpoint = _get_spawnpoint(editor)
+
+    editor.copy_actor(
+        name_of_scenario, (-500.0, 9230.0, 0.0), trigger, name_of_trigger, 0,
+    )
+
+    spawnpoint_actor = editor.copy_actor(
+        name_of_scenario, (-500.0, 9230.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+    )
+
+    scenario_7.add_actor_to_entity_groups("collision_camera_061", name_of_trigger)
+    scenario_7.add_actor_to_entity_groups("collision_camera_061", name_of_spawnpoint)
+
+    trigger_actor = scenario_7.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
+    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_003_Omega_001"
+
+    spawnpoint_actor["rotation"][1] = -90
+
+
 def patch_metroids(editor: PatcherEditor):
     _patch_metroids(editor)
-    _create_checkpoint_gamma_2b(editor)
+    _create_checkpoint_alpha_surface(editor)
+    _create_checkpoint_alpha_003_area2(editor)
+    _create_checkpoint_gamma_area2b(editor)
+    _create_checkpoint_alpha_002_area3b(editor)
+    _create_checkpoint_alpha_area6(editor)
+    _create_checkpoint_zeta_area7(editor)
+    _create_checkpoint_omega_area7_out(editor)
+    _create_checkpoint_omega_area7_1(editor)
+    _create_checkpoint_omega_area7_2(editor)

--- a/open_samus_returns_rando/specific_patches/metroid_patches.py
+++ b/open_samus_returns_rando/specific_patches/metroid_patches.py
@@ -123,11 +123,11 @@ def _create_checkpoint_alpha_003_area2(editor: PatcherEditor):
     )
 
     editor.copy_actor(
-        name_of_scenario, (-18300.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+        name_of_scenario, (-18800.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
     )
 
     spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (-18300.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
+        name_of_scenario, (-18800.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
     )
 
     scenario_2.add_actor_to_entity_groups("collision_camera_028", name_of_trigger)
@@ -151,15 +151,15 @@ def _create_checkpoint_gamma_area2b(editor: PatcherEditor):
     spawnpoint = _get_spawnpoint(editor)
 
     editor.copy_actor(
-        name_of_scenario, (-1650.0, -4500.0, 0.0), trigger, name_of_trigger, 0,
+        name_of_scenario, (-1800.0, -4500.0, 0.0), trigger, name_of_trigger, 0,
     )
 
     spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (-1500.0, -4500.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+        name_of_scenario, (-1550.0, -4500.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
     )
 
     editor.copy_actor(
-        name_of_scenario, (-1500.0, -4500.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
+        name_of_scenario, (-1550.0, -4500.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
     )
 
     scenario_2b.add_actor_to_entity_groups("collision_camera039", name_of_trigger)
@@ -168,38 +168,6 @@ def _create_checkpoint_gamma_area2b(editor: PatcherEditor):
 
     trigger_actor = scenario_2b.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
     trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Gamma_001"
-
-    spawnpoint_actor["rotation"][1] = -90
-
-
-def _create_checkpoint_alpha_002_area3b(editor: PatcherEditor):
-    name_of_scenario = "s033_area3b"
-    scenario_3b = editor.get_scenario(name_of_scenario)
-    name_of_trigger = "TG_SetCheckpoint_002_Alpha_002"
-    name_of_spawnpoint = "ST_SG_Alpha_002B"
-    name_of_spawnpoint_out = "ST_SG_Alpha_002B_Out"
-
-    trigger = _get_trigger(editor)
-    spawnpoint = _get_spawnpoint(editor)
-
-    editor.copy_actor(
-        name_of_scenario, (-17800.0, 800.0, 0.0), trigger, name_of_trigger, 0,
-    )
-
-    editor.copy_actor(
-        name_of_scenario, (-18300.0, 800.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
-    )
-
-    spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (-18300.0, 800.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
-    )
-
-    scenario_3b.add_actor_to_entity_groups("collision_camera_037", name_of_trigger)
-    scenario_3b.add_actor_to_entity_groups("collision_camera_037", name_of_spawnpoint)
-    scenario_3b.add_actor_to_entity_groups("collision_camera_037", name_of_spawnpoint_out)
-
-    trigger_actor = scenario_3b.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
-    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Alpha_002"
 
     spawnpoint_actor["rotation"][1] = -90
 
@@ -219,11 +187,11 @@ def _create_checkpoint_alpha_area6(editor: PatcherEditor):
     )
 
     editor.copy_actor(
-        name_of_scenario, (2800.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+        name_of_scenario, (2850.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
     )
 
     spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (2800.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
+        name_of_scenario, (2850.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
     )
 
     scenario_6.add_actor_to_entity_groups("collision_camera_015", name_of_trigger)
@@ -251,11 +219,11 @@ def _create_checkpoint_zeta_area7(editor: PatcherEditor):
     )
 
     spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (6900.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+        name_of_scenario, (6850.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
     )
 
     editor.copy_actor(
-        name_of_scenario, (6900.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
+        name_of_scenario, (6850.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
     )
 
     scenario_7.add_actor_to_entity_groups("collision_camera_040", name_of_trigger)
@@ -282,7 +250,7 @@ def _create_checkpoint_omega_area7_out(editor: PatcherEditor):
     scenario_7.add_actor_to_entity_groups("collision_camera_047", name_of_spawnpoint_out)
 
 
-def _create_checkpoint_omega_area7_1(editor: PatcherEditor):
+def _create_checkpoint_omega_area7_left(editor: PatcherEditor):
     name_of_scenario = "s070_area7"
     scenario_7 = editor.get_scenario(name_of_scenario)
     name_of_trigger = "TG_SetCheckpoint_002_Omega_001"
@@ -297,11 +265,11 @@ def _create_checkpoint_omega_area7_1(editor: PatcherEditor):
     )
 
     editor.copy_actor(
-        name_of_scenario, (-2200.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+        name_of_scenario, (-2250.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
     )
 
     spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (-2200.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
+        name_of_scenario, (-2250.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
     )
 
     scenario_7.add_actor_to_entity_groups("collision_camera_046", name_of_trigger)
@@ -314,7 +282,7 @@ def _create_checkpoint_omega_area7_1(editor: PatcherEditor):
     spawnpoint_actor["rotation"][1] = -90
 
 
-def _create_checkpoint_omega_area7_2(editor: PatcherEditor):
+def _create_checkpoint_omega_area7_top(editor: PatcherEditor):
     name_of_scenario = "s070_area7"
     scenario_7 = editor.get_scenario(name_of_scenario)
     name_of_trigger = "TG_SetCheckpoint_003_Omega_001"
@@ -324,11 +292,11 @@ def _create_checkpoint_omega_area7_2(editor: PatcherEditor):
     spawnpoint = _get_spawnpoint(editor)
 
     editor.copy_actor(
-        name_of_scenario, (-500.0, 9230.0, 0.0), trigger, name_of_trigger, 0,
+        name_of_scenario, (-1025.0, 9700.0, 0.0), trigger, name_of_trigger, 0,
     )
 
     spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (-500.0, 9230.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
+        name_of_scenario, (-1025.0, 9700.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
     )
 
     scenario_7.add_actor_to_entity_groups("collision_camera_061", name_of_trigger)
@@ -345,9 +313,8 @@ def patch_metroids(editor: PatcherEditor):
     _create_checkpoint_alpha_surface(editor)
     _create_checkpoint_alpha_003_area2(editor)
     _create_checkpoint_gamma_area2b(editor)
-    _create_checkpoint_alpha_002_area3b(editor)
     _create_checkpoint_alpha_area6(editor)
     _create_checkpoint_zeta_area7(editor)
     _create_checkpoint_omega_area7_out(editor)
-    _create_checkpoint_omega_area7_1(editor)
-    _create_checkpoint_omega_area7_2(editor)
+    _create_checkpoint_omega_area7_left(editor)
+    _create_checkpoint_omega_area7_top(editor)


### PR DESCRIPTION
Did not test most of these since it requires https://github.com/randovania/mercury-engine-data-structures/pull/88 to be merged first, otherwise rooms break
 
- Added checkpoints to all but two multi-room Metroids (skipped ones connect to an item room so checkpoint isn't that important)
- Renamed Gamma 2b checkpoints to match the vanilla naming scheme