### PR TITLE
Update Map icons

### DIFF
--- a/open_samus_returns_rando/custom_pickups.py
+++ b/open_samus_returns_rando/custom_pickups.py
@@ -6,7 +6,7 @@ from open_samus_returns_rando.patcher_editor import PatcherEditor
 BABY_ICON = Container({
     "actor_name": "LE_Baby_Hatchling",
     "clear_condition": "",
-    "icon": "itemsphere",
+    "icon": "itemenabled",
     "icon_priority": 0,
     "coordinates": ListContainer([
         -3400.0,

--- a/open_samus_returns_rando/custom_pickups.py
+++ b/open_samus_returns_rando/custom_pickups.py
@@ -1,4 +1,19 @@
+from construct import Container, ListContainer
+from mercury_engine_data_structures.formats import Bmsmsd
+
 from open_samus_returns_rando.patcher_editor import PatcherEditor
+
+BABY_ICON = Container({
+    "actor_name": "LE_Baby_Hatchling",
+    "clear_condition": "",
+    "icon": "itemsphere",
+    "icon_priority": 0,
+    "coordinates": ListContainer([
+        -3400.0,
+        11225.0,
+        0.0
+    ]),
+})
 
 
 def _get_actor(editor: PatcherEditor):
@@ -24,7 +39,9 @@ def _create_baby_pickup(editor: PatcherEditor):
 
     scenario_10.add_actor_to_entity_groups("collision_camera_022", name_of_pickup)
 
-    # TODO: Update minimap
+    area10 = editor.get_file("gui/minimaps/c10_samus/s100_area10.bmsmsd", Bmsmsd)
+    mapicon = area10.raw["tiles"][252]
+    mapicon["icons"] = ListContainer([BABY_ICON])
 
 
 def patch_custom_pickups(editor: PatcherEditor):

--- a/open_samus_returns_rando/pickup.py
+++ b/open_samus_returns_rando/pickup.py
@@ -196,8 +196,6 @@ class ActorPickup(BasePickup):
         model_names: list[str] = self.pickup["model"]
         self.patch_model(model_names, new_template)
 
-        # TODO Update minimap
-
         # Update caption
         pickable = new_template["components"]["PICKABLE"]
         # this actually wants an #GUI identifier but it works
@@ -229,10 +227,6 @@ class ActorPickup(BasePickup):
                 for dep in model_data.dependencies:
                     editor.ensure_present(get_package_name(level_pkg, dep), dep)
 
-        # For debugging, write the bmsad we just created
-        # Path("custom_bmsad", f"randomizer_powerup_{i}.bmsad.json").write_text(
-        #     json.dumps(new_template, indent=4)
-        # )
 
 class MetroidPickup(BasePickup):
     def patch(self, editor: PatcherEditor):

--- a/open_samus_returns_rando/samus_returns_patcher.py
+++ b/open_samus_returns_rando/samus_returns_patcher.py
@@ -18,6 +18,7 @@ from open_samus_returns_rando.pickup import patch_pickups
 from open_samus_returns_rando.specific_patches import game_patches
 from open_samus_returns_rando.specific_patches.door_patches import patch_doors
 from open_samus_returns_rando.specific_patches.heat_room_patches import patch_heat_rooms
+from open_samus_returns_rando.specific_patches.map_icons import update_map_icons
 from open_samus_returns_rando.specific_patches.metroid_patches import patch_metroids
 from open_samus_returns_rando.specific_patches.static_fixes import apply_static_fixes
 from open_samus_returns_rando.specific_patches.tunable_patches import patch_tunables
@@ -125,6 +126,9 @@ def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
     # Text patches
     patch_credits(editor, configuration["spoiler_log"])
     patch_pb_status(editor)
+
+    # Map Icons
+    update_map_icons(editor)
 
     out_romfs = output_path.joinpath("romfs")
     out_exefs = output_path.joinpath("exefs")

--- a/open_samus_returns_rando/samus_returns_patcher.py
+++ b/open_samus_returns_rando/samus_returns_patcher.py
@@ -18,7 +18,7 @@ from open_samus_returns_rando.pickup import patch_pickups
 from open_samus_returns_rando.specific_patches import game_patches
 from open_samus_returns_rando.specific_patches.door_patches import patch_doors
 from open_samus_returns_rando.specific_patches.heat_room_patches import patch_heat_rooms
-from open_samus_returns_rando.specific_patches.map_icons import update_map_icons
+from open_samus_returns_rando.specific_patches.map_icons import patch_tiles
 from open_samus_returns_rando.specific_patches.metroid_patches import patch_metroids
 from open_samus_returns_rando.specific_patches.static_fixes import apply_static_fixes
 from open_samus_returns_rando.specific_patches.tunable_patches import patch_tunables
@@ -99,7 +99,7 @@ def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
     lua_util.replace_script(editor, "actors/props/savestation/scripts/savestation", "custom_savestation.lua")
 
     # Update Map Icons
-    update_map_icons(editor)
+    patch_tiles(editor)
 
     # Custom pickups
     patch_custom_pickups(editor)

--- a/open_samus_returns_rando/samus_returns_patcher.py
+++ b/open_samus_returns_rando/samus_returns_patcher.py
@@ -98,6 +98,9 @@ def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
     lua_util.replace_script(editor, "actors/props/samusship/scripts/samusship", "custom_ship.lua")
     lua_util.replace_script(editor, "actors/props/savestation/scripts/savestation", "custom_savestation.lua")
 
+    # Update Map Icons
+    update_map_icons(editor)
+
     # Custom pickups
     patch_custom_pickups(editor)
     debug_custom_pickups(editor, configuration["debug_custom_pickups"])
@@ -126,9 +129,6 @@ def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
     # Text patches
     patch_credits(editor, configuration["spoiler_log"])
     patch_pb_status(editor)
-
-    # Map Icons
-    update_map_icons(editor)
 
     out_romfs = output_path.joinpath("romfs")
     out_exefs = output_path.joinpath("exefs")

--- a/open_samus_returns_rando/specific_patches/door_patches.py
+++ b/open_samus_returns_rando/specific_patches/door_patches.py
@@ -174,7 +174,7 @@ def _patch_one_way_doors(editor: PatcherEditor):
         # Below Wave Beam
         "s025_area2b": ["Door008"],
         # Below Chozo Seal
-        "s030_area3": ["Door003", "Door006"],
+        "s030_area3": ["Door005", "Door006"],
         # Chozo Seal Spazer Door
         "s040_area4": ["Door001"],
         # Plasma Room Plasma and Missile doors, Gravity Room Missile Door

--- a/open_samus_returns_rando/specific_patches/map_icons.py
+++ b/open_samus_returns_rando/specific_patches/map_icons.py
@@ -1,11 +1,24 @@
-from construct import ListContainer
 from mercury_engine_data_structures.formats import Bmsmsd
 
 from open_samus_returns_rando.constants import ALL_AREAS
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 
-def _patch_tiles(tiles: ListContainer, editor: PatcherEditor):
+def patch_tiles(editor: PatcherEditor):
+    DOORS = {
+        "s000_surface": ["Door004", "Door011"],
+        "s010_area1": ["Door002", "Door004", "Door012", "Door016"],
+        "s025_area2b": ["Door008"],
+        "s028_area2c": ["Door001", "Door007"],
+        "s030_area3": ["Door002", "Door005", "Door006", "Door008"],
+        "s040_area4": ["Door001", "Door006", "Door014"],
+        "s050_area5": ["Door006"],
+        "s060_area6": ["Door001"],
+        "s067_area6c": ["Door005", "Door006", "Door009"],
+        "s070_area7": ["Door010"],
+        "s090_area9": ["Door012"],
+    }
+
     for area in ALL_AREAS:
         if area != "s110_surfaceb":
             scenario = editor.get_file(f"gui/minimaps/c10_samus/{area}.bmsmsd", Bmsmsd)
@@ -27,146 +40,13 @@ def _patch_tiles(tiles: ListContainer, editor: PatcherEditor):
                     else:
                         icons[0]["icon"] = "itemenabled"
 
-
-def _surface_doors(editor: PatcherEditor):
-    surface = editor.get_file("gui/minimaps/c10_samus/s000_surface.bmsmsd", Bmsmsd)
-    mapicon = surface.raw["tiles"]
-
-    # Door004, Door011 (Chozo Seal Charge Doors)
-    mapicon[99]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[100]["icons"][0]["icon"] = "doorpowerright"
-
-    mapicon[57]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[58]["icons"][0]["icon"] = "doorpowerright"
-
-
-def _area1_doors(editor: PatcherEditor):
-    area1 = editor.get_file("gui/minimaps/c10_samus/s010_area1.bmsmsd", Bmsmsd)
-    mapicon = area1.raw["tiles"]
-
-    # Door002 (Chozo Seal Charge Door)
-    mapicon[77]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[78]["icons"][0]["icon"] = "doorpowerright"
-
-    # Door004 (Bombs)
-    mapicon[194]["icons"][0]["icon"] = "doorpowerleft"
-
-    # Door012 (Right Exterior Door -> Interior)
-    mapicon[266]["icons"][0]["clear_condition"] = ""
-    mapicon[267]["icons"][0]["icon"] = "doorpowerright"
-
-    # Door016 (Exterior Alpha)
-    mapicon[302]["icons"][0]["icon"] = "doorpowerright"
-
-
-def _area2b_doors(editor: PatcherEditor):
-    area2b = editor.get_file("gui/minimaps/c10_samus/s025_area2b.bmsmsd", Bmsmsd)
-    mapicon = area2b.raw["tiles"]
-
-    # Door008 (Below Wave Beam)
-    mapicon[152]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[153]["icons"][0]["clear_condition"] = ""
-
-
-def _area2c_doors(editor: PatcherEditor):
-    area2c = editor.get_file("gui/minimaps/c10_samus/s028_area2c.bmsmsd", Bmsmsd)
-    mapicon = area2c.raw["tiles"]
-
-    # Door001, Door007 (Chozo Seal Charge Doors)
-    mapicon[50]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[51]["icons"][0]["icon"] = "doorpowerright"
-
-    mapicon[32]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[33]["icons"][0]["icon"] = "doorpowerright"
-
-
-def _area3_doors(editor: PatcherEditor):
-    area3 = editor.get_file("gui/minimaps/c10_samus/s030_area3.bmsmsd", Bmsmsd)
-    mapicon = area3.raw["tiles"]
-
-    # Door002, Door008 (Chozo Seal Charge Doors)
-    mapicon[54]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[55]["icons"][0]["icon"] = "doorpowerright"
-
-    mapicon[2]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[3]["icons"][0]["icon"] = "doorpowerright"
-
-
-def _area4_doors(editor: PatcherEditor):
-    area4 = editor.get_file("gui/minimaps/c10_samus/s040_area4.bmsmsd", Bmsmsd)
-    mapicon = area4.raw["tiles"]
-
-    # Door001 (Chozo Seal Spazer Door)
-    mapicon[161]["icons"][1]["icon"] = "doorspazerleft"
-
-    # Door006 (Chozo Seal Charge Door)
-    mapicon[141]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[142]["icons"][0]["icon"] = "doorpowerright"
-
-    # Door014 (The Big Gap Charge Door)
-    mapicon[2]["icons"][1]["icon"] = "doorpowerleft"
-    mapicon[3]["icons"][0]["icon"] = "doorpowerright"
-
-
-def _area5_doors(editor: PatcherEditor):
-    area5 = editor.get_file("gui/minimaps/c10_samus/s050_area5.bmsmsd", Bmsmsd)
-    mapicon = area5.raw["tiles"]
-
-    # Door006 (Elevator Charge Door)
-    mapicon[100]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[101]["icons"][0]["icon"] = "doorpowerright"
-
-
-def _area6_doors(editor: PatcherEditor):
-    area6 = editor.get_file("gui/minimaps/c10_samus/s060_area6.bmsmsd", Bmsmsd)
-    mapicon = area6.raw["tiles"]
-
-    # Door001 (Entrance Charge Door)
-    mapicon[14]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[15]["icons"][0]["icon"] = "doorpowerright"
-
-
-def _area6c_doors(editor: PatcherEditor):
-    area6c = editor.get_file("gui/minimaps/c10_samus/s067_area6c.bmsmsd", Bmsmsd)
-    mapicon = area6c.raw["tiles"]
-
-    # Door005 (Plasma Beam Missile Door)
-    mapicon[32]["icons"][0]["icon"] = "doorpowerleft"
-
-    # Door006 (Plasma Beam Plasma Door)
-    mapicon[35]["icons"][0]["icon"] = "doorpowerleft"
-
-    # Door009 (Gravity Suit Missile Door)
-    mapicon[149]["icons"][0]["icon"] = "doorpowerleft"
-
-
-def _area7_doors(editor: PatcherEditor):
-    area7 = editor.get_file("gui/minimaps/c10_samus/s070_area7.bmsmsd", Bmsmsd)
-    mapicon = area7.raw["tiles"]
-
-    # Door010 (Pre-Steal Charge Door)
-    mapicon[273]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[274]["icons"][0]["icon"] = "doorpowerright"
-
-
-def _area9_doors(editor: PatcherEditor):
-    area9 = editor.get_file("gui/minimaps/c10_samus/s090_area9.bmsmsd", Bmsmsd)
-    mapicon = area9.raw["tiles"]
-
-    # Door012 (Chozo Seal Charge Door)
-    mapicon[89]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[90]["icons"][0]["icon"] = "doorpowerright"
-
-def update_map_icons(editor: PatcherEditor):
-    _patch_tiles(ListContainer, editor)
-    _surface_doors(editor)
-    _area1_doors(editor)
-    _area2b_doors(editor)
-    _area2c_doors(editor)
-    _area3_doors(editor)
-    _area4_doors(editor)
-    _area5_doors(editor)
-    _area6_doors(editor)
-    _area6c_doors(editor)
-    _area7_doors(editor)
-    _area9_doors(editor)
+                for door in DOORS.get(area, []):
+                    if len(icons) == 1 and icons[0]["actor_name"].startswith(door):
+                        icons[0]["clear_condition"] = ""
+                        if "left" in icons[0]["icon"]:
+                            icons[0]["icon"] = "doorpowerleft"
+                        else:
+                            icons[0]["icon"] = "doorpowerright"
+                    if len(icons) == 2 and icons[1]["actor_name"].startswith(door) and "left" in icons[1]["icon"]:
+                        icons[1]["clear_condition"] = ""
+                        icons[1]["icon"] = "doorpowerleft"

--- a/open_samus_returns_rando/specific_patches/map_icons.py
+++ b/open_samus_returns_rando/specific_patches/map_icons.py
@@ -1,0 +1,203 @@
+from mercury_engine_data_structures.formats import Bmsmsd
+
+from open_samus_returns_rando.patcher_editor import PatcherEditor
+
+
+def _surface_icons(editor: PatcherEditor):
+    surface = editor.get_file("gui/minimaps/c10_samus/s000_surface.bmsmsd", Bmsmsd)
+    mapicon = surface.raw["tiles"]
+
+    # Doors
+    # Door004, Door011 (Chozo Seal Charge Doors)
+    mapicon[99]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[100]["icons"][0]["icon"] = "doorpowerright"
+
+    mapicon[57]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[58]["icons"][0]["icon"] = "doorpowerright"
+
+    # Hazardous Tiles
+    for tile in range(89):
+        if mapicon[tile]["tile_type"] == 4:
+            mapicon[tile]["tile_type"] = 1
+
+
+def _area1_icons(editor: PatcherEditor):
+    area1 = editor.get_file("gui/minimaps/c10_samus/s010_area1.bmsmsd", Bmsmsd)
+    mapicon = area1.raw["tiles"]
+
+    # Doors
+    # Door002 (Chozo Seal Charge Door)
+    mapicon[77]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[78]["icons"][0]["icon"] = "doorpowerright"
+
+    # Door004 (Bombs)
+    mapicon[194]["icons"][0]["icon"] = "doorpowerleft"
+
+    # Door012 (Right Exterior Door -> Interior)
+    mapicon[266]["icons"][0]["clear_condition"] = ""
+    mapicon[267]["icons"][0]["icon"] = "doorpowerright"
+
+    # Door016 (Exterior Alpha)
+    mapicon[302]["icons"][0]["icon"] = "doorpowerright"
+
+    # Hazardous Tiles
+    for tile in range(52):
+        if mapicon[tile]["tile_type"] == 4:
+            mapicon[tile]["tile_type"] = 1
+
+
+def _area2b_icons(editor: PatcherEditor):
+    area2b = editor.get_file("gui/minimaps/c10_samus/s025_area2b.bmsmsd", Bmsmsd)
+    mapicon = area2b.raw["tiles"]
+
+    # Doors
+    # Door008 (Below Wave Beam)
+    mapicon[152]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[153]["icons"][0]["clear_condition"] = ""
+
+
+def _area2c_icons(editor: PatcherEditor):
+    area2c = editor.get_file("gui/minimaps/c10_samus/s028_area2c.bmsmsd", Bmsmsd)
+    mapicon = area2c.raw["tiles"]
+
+    # Doors
+    # Door001, Door007 (Chozo Seal Charge Doors)
+    mapicon[50]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[51]["icons"][0]["icon"] = "doorpowerright"
+
+    mapicon[32]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[33]["icons"][0]["icon"] = "doorpowerright"
+
+    # Hazardous Tiles
+    for tile in range(37):
+        if mapicon[tile]["tile_type"] == 4:
+            mapicon[tile]["tile_type"] = 1
+
+
+def _area3_icons(editor: PatcherEditor):
+    area3 = editor.get_file("gui/minimaps/c10_samus/s030_area3.bmsmsd", Bmsmsd)
+    mapicon = area3.raw["tiles"]
+
+    # Doors
+    # Door002, Door008 (Chozo Seal Charge Doors)
+    mapicon[54]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[55]["icons"][0]["icon"] = "doorpowerright"
+
+    mapicon[2]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[3]["icons"][0]["icon"] = "doorpowerright"
+
+    # Hazardous Tiles
+    for tile in range(44):
+        if mapicon[tile]["tile_type"] == 4:
+            mapicon[tile]["tile_type"] = 1
+
+
+def _area4_icons(editor: PatcherEditor):
+    area4 = editor.get_file("gui/minimaps/c10_samus/s040_area4.bmsmsd", Bmsmsd)
+    mapicon = area4.raw["tiles"]
+
+    # Doors
+    # Door001 (Chozo Seal Spazer Door)
+    mapicon[161]["icons"][1]["icon"] = "doorspazerleft"
+
+    # Door006 (Chozo Seal Charge Door)
+    mapicon[141]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[142]["icons"][0]["icon"] = "doorpowerright"
+
+    # Door014 (The Big Gap Charge Door)
+    mapicon[2]["icons"][1]["icon"] = "doorpowerleft"
+    mapicon[3]["icons"][0]["icon"] = "doorpowerright"
+
+    # Hazardous Tiles
+    for tile in range(40):
+        if mapicon[tile]["tile_type"] == 4:
+            mapicon[tile]["tile_type"] = 1
+
+
+def _area5_icons(editor: PatcherEditor):
+    area5 = editor.get_file("gui/minimaps/c10_samus/s050_area5.bmsmsd", Bmsmsd)
+    mapicon = area5.raw["tiles"]
+
+    # Doors
+    # Door006 (Elevator Charge Door)
+    mapicon[100]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[100]["icons"][0]["icon"] = "doorpowerright"
+
+    # Hazardous Tiles
+    for tile in range(40):
+        if mapicon[tile]["tile_type"] == 4:
+            mapicon[tile]["tile_type"] = 1
+
+
+def _area6_icons(editor: PatcherEditor):
+    area6 = editor.get_file("gui/minimaps/c10_samus/s060_area6.bmsmsd", Bmsmsd)
+    mapicon = area6.raw["tiles"]
+
+    # Doors
+    # Door001 (Entrance Charge Door)
+    mapicon[14]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[15]["icons"][0]["icon"] = "doorpowerright"
+
+    # Hazardous Tiles
+    for tile in range(42):
+        if mapicon[tile]["tile_type"] == 4:
+            mapicon[tile]["tile_type"] = 1
+
+
+def _area6c_icons(editor: PatcherEditor):
+    area6c = editor.get_file("gui/minimaps/c10_samus/s067_area6c.bmsmsd", Bmsmsd)
+    mapicon = area6c.raw["tiles"]
+
+    # Doors
+    # Door005 (Plasma Beam Missile Door)
+    mapicon[32]["icons"][0]["icon"] = "doorpowerleft"
+
+    # Door006 (Plasma Beam Plasma Door)
+    mapicon[35]["icons"][0]["icon"] = "doorpowerleft"
+
+    # Door009 (Gravity Suit Missile Door)
+    mapicon[149]["icons"][0]["icon"] = "doorpowerleft"
+
+
+def _area7_icons(editor: PatcherEditor):
+    area7 = editor.get_file("gui/minimaps/c10_samus/s070_area7.bmsmsd", Bmsmsd)
+    mapicon = area7.raw["tiles"]
+
+    # Doors
+    # Door010 (Chozo Seal Charge Door)
+    mapicon[273]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[274]["icons"][0]["icon"] = "doorpowerright"
+
+    # Hazardous Tiles
+    for tile in range(49):
+        if mapicon[tile]["tile_type"] == 4:
+            mapicon[tile]["tile_type"] = 1
+
+
+def _area9_icons(editor: PatcherEditor):
+    area9 = editor.get_file("gui/minimaps/c10_samus/s090_area9.bmsmsd", Bmsmsd)
+    mapicon = area9.raw["tiles"]
+
+    # Doors
+    # Door012 (Elevator Charge Door)
+    mapicon[89]["icons"][0]["icon"] = "doorpowerleft"
+    mapicon[90]["icons"][0]["icon"] = "doorpowerright"
+
+    # Hazardous Tiles
+    for tile in range(61):
+        if mapicon[tile]["tile_type"] == 4:
+            mapicon[tile]["tile_type"] = 1
+
+
+def update_map_icons(editor: PatcherEditor):
+    _surface_icons(editor)
+    _area1_icons(editor)
+    _area2b_icons(editor)
+    _area2c_icons(editor)
+    _area3_icons(editor)
+    _area4_icons(editor)
+    _area5_icons(editor)
+    _area6_icons(editor)
+    _area6c_icons(editor)
+    _area7_icons(editor)
+    _area9_icons(editor)

--- a/open_samus_returns_rando/specific_patches/map_icons.py
+++ b/open_samus_returns_rando/specific_patches/map_icons.py
@@ -1,13 +1,37 @@
+from construct import ListContainer
 from mercury_engine_data_structures.formats import Bmsmsd
 
+from open_samus_returns_rando.constants import ALL_AREAS
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 
-def _surface_icons(editor: PatcherEditor):
+def _patch_tiles(tiles: ListContainer, editor: PatcherEditor):
+    for area in ALL_AREAS:
+        if area != "s110_surfaceb":
+            scenario = editor.get_file(f"gui/minimaps/c10_samus/{area}.bmsmsd", Bmsmsd)
+            tiles = scenario.raw["tiles"]
+            for tile_idx in range(len(tiles)):
+                current_tile = tiles[tile_idx]
+                # Hazardous Tiles
+                if current_tile["tile_type"] in {"ACID", "ACID_RISE", "ACID_FALL"}:
+                    current_tile["tile_type"] = "NORMAL"
+
+                # Items
+                icons = current_tile["icons"]
+                if len(icons) != 0 and (
+                    icons[0]["icon"].endswith("tank")
+                    or icons[0]["icon"].startswith("itemsphere")
+                ):
+                    if current_tile["tile_type"] == "HEAT":
+                        icons[0]["icon"] = "itemenabledheat"
+                    else:
+                        icons[0]["icon"] = "itemenabled"
+
+
+def _surface_doors(editor: PatcherEditor):
     surface = editor.get_file("gui/minimaps/c10_samus/s000_surface.bmsmsd", Bmsmsd)
     mapicon = surface.raw["tiles"]
 
-    # Doors
     # Door004, Door011 (Chozo Seal Charge Doors)
     mapicon[99]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[100]["icons"][0]["icon"] = "doorpowerright"
@@ -15,24 +39,11 @@ def _surface_icons(editor: PatcherEditor):
     mapicon[57]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[58]["icons"][0]["icon"] = "doorpowerright"
 
-    for tile in range(479):
-        # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == "ACID":
-            mapicon[tile]["tile_type"] = "NORMAL"
-        # Items
-        if mapicon[tile]["icons"] != ([]) and (
-            mapicon[tile]["icons"][0]["icon"].endswith("tank")
-            or mapicon[tile]["icons"][0]["icon"].startswith("itemsphere")
-            or mapicon[tile]["icons"][0]["icon"].startswith("spenergy")
-        ):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
-
-def _area1_icons(editor: PatcherEditor):
+def _area1_doors(editor: PatcherEditor):
     area1 = editor.get_file("gui/minimaps/c10_samus/s010_area1.bmsmsd", Bmsmsd)
     mapicon = area1.raw["tiles"]
 
-    # Doors
     # Door002 (Chozo Seal Charge Door)
     mapicon[77]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[78]["icons"][0]["icon"] = "doorpowerright"
@@ -47,53 +58,20 @@ def _area1_icons(editor: PatcherEditor):
     # Door016 (Exterior Alpha)
     mapicon[302]["icons"][0]["icon"] = "doorpowerright"
 
-    for tile in range(384):
-        # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == "ACID":
-            mapicon[tile]["tile_type"] = "NORMAL"
-        # Items
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
-            "icon"
-        ].startswith("item"):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
-    mapicon[158]["icons"][0]["icon"] = "itemenabledheat"
 
-
-def _area2_icons(editor: PatcherEditor):
-    area2 = editor.get_file("gui/minimaps/c10_samus/s020_area2.bmsmsd", Bmsmsd)
-    mapicon = area2.raw["tiles"]
-
-    # Items
-    for tile in range(310):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
-            "icon"
-        ].startswith("item"):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
-
-
-def _area2b_icons(editor: PatcherEditor):
+def _area2b_doors(editor: PatcherEditor):
     area2b = editor.get_file("gui/minimaps/c10_samus/s025_area2b.bmsmsd", Bmsmsd)
     mapicon = area2b.raw["tiles"]
 
-    # Doors
     # Door008 (Below Wave Beam)
     mapicon[152]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[153]["icons"][0]["clear_condition"] = ""
 
-    # Items
-    for tile in range(160):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
-            "icon"
-        ].startswith("item"):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
-    mapicon[88]["icons"][0]["icon"] = "itemenabledheat"
 
-
-def _area2c_icons(editor: PatcherEditor):
+def _area2c_doors(editor: PatcherEditor):
     area2c = editor.get_file("gui/minimaps/c10_samus/s028_area2c.bmsmsd", Bmsmsd)
     mapicon = area2c.raw["tiles"]
 
-    # Doors
     # Door001, Door007 (Chozo Seal Charge Doors)
     mapicon[50]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[51]["icons"][0]["icon"] = "doorpowerright"
@@ -101,23 +79,11 @@ def _area2c_icons(editor: PatcherEditor):
     mapicon[32]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[33]["icons"][0]["icon"] = "doorpowerright"
 
-    for tile in range(116):
-        # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == "ACID":
-            mapicon[tile]["tile_type"] = "NORMAL"
-        # Items
-        if mapicon[tile]["icons"] != ([]) and (
-            mapicon[tile]["icons"][0]["icon"].startswith("item")
-            or mapicon[tile]["icons"][0]["icon"].startswith("spenergy")
-        ):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
-
-def _area3_icons(editor: PatcherEditor):
+def _area3_doors(editor: PatcherEditor):
     area3 = editor.get_file("gui/minimaps/c10_samus/s030_area3.bmsmsd", Bmsmsd)
     mapicon = area3.raw["tiles"]
 
-    # Doors
     # Door002, Door008 (Chozo Seal Charge Doors)
     mapicon[54]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[55]["icons"][0]["icon"] = "doorpowerright"
@@ -125,47 +91,11 @@ def _area3_icons(editor: PatcherEditor):
     mapicon[2]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[3]["icons"][0]["icon"] = "doorpowerright"
 
-    for tile in range(300):
-        # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == "ACID":
-            mapicon[tile]["tile_type"] = "NORMAL"
-        # Items
-        if mapicon[tile]["icons"] != ([]) and (
-            mapicon[tile]["icons"][0]["icon"].startswith("item")
-            or mapicon[tile]["icons"][0]["icon"].startswith("spenergy")
-        ):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
-
-def _area3b_icons(editor: PatcherEditor):
-    area3b = editor.get_file("gui/minimaps/c10_samus/s033_area3b.bmsmsd", Bmsmsd)
-    mapicon = area3b.raw["tiles"]
-
-    # Items
-    for tile in range(323):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
-            "icon"
-        ].startswith("item"):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
-
-
-def _area3c_icons(editor: PatcherEditor):
-    area3c = editor.get_file("gui/minimaps/c10_samus/s036_area3c.bmsmsd", Bmsmsd)
-    mapicon = area3c.raw["tiles"]
-
-    # Items
-    for tile in range(150):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
-            "icon"
-        ].startswith("item"):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
-
-
-def _area4_icons(editor: PatcherEditor):
+def _area4_doors(editor: PatcherEditor):
     area4 = editor.get_file("gui/minimaps/c10_samus/s040_area4.bmsmsd", Bmsmsd)
     mapicon = area4.raw["tiles"]
 
-    # Doors
     # Door001 (Chozo Seal Spazer Door)
     mapicon[161]["icons"][1]["icon"] = "doorspazerleft"
 
@@ -177,73 +107,29 @@ def _area4_icons(editor: PatcherEditor):
     mapicon[2]["icons"][1]["icon"] = "doorpowerleft"
     mapicon[3]["icons"][0]["icon"] = "doorpowerright"
 
-    for tile in range(285):
-        # Hazardous Tiles
-        if mapicon[tile]["tile_type"] in {"ACID", "ACID_FALL"}:
-            mapicon[tile]["tile_type"] = "NORMAL"
-        # Items
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
-            "icon"
-        ].startswith("item"):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
-
-def _area5_icons(editor: PatcherEditor):
+def _area5_doors(editor: PatcherEditor):
     area5 = editor.get_file("gui/minimaps/c10_samus/s050_area5.bmsmsd", Bmsmsd)
     mapicon = area5.raw["tiles"]
 
-    # Doors
     # Door006 (Elevator Charge Door)
     mapicon[100]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[101]["icons"][0]["icon"] = "doorpowerright"
 
-    # Items
-    for tile in range(296):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
-            "icon"
-        ].startswith("item"):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
-    mapicon[213]["icons"][0]["icon"] = "itemenabledheat"
 
-
-def _area6_icons(editor: PatcherEditor):
+def _area6_doors(editor: PatcherEditor):
     area6 = editor.get_file("gui/minimaps/c10_samus/s060_area6.bmsmsd", Bmsmsd)
     mapicon = area6.raw["tiles"]
 
-    # Doors
     # Door001 (Entrance Charge Door)
     mapicon[14]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[15]["icons"][0]["icon"] = "doorpowerright"
 
-    for tile in range(226):
-        # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == "ACID":
-            mapicon[tile]["tile_type"] = "NORMAL"
-        # Items
-        if mapicon[tile]["icons"] != ([]) and (
-            mapicon[tile]["icons"][0]["icon"].startswith("item")
-            or mapicon[tile]["icons"][0]["icon"].startswith("spenergy")
-        ):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
-
-def _area6b_icons(editor: PatcherEditor):
-    area6b = editor.get_file("gui/minimaps/c10_samus/s065_area6b.bmsmsd", Bmsmsd)
-    mapicon = area6b.raw["tiles"]
-
-    # Items
-    for tile in range(290):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
-            "icon"
-        ].startswith("item"):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
-
-
-def _area6c_icons(editor: PatcherEditor):
+def _area6c_doors(editor: PatcherEditor):
     area6c = editor.get_file("gui/minimaps/c10_samus/s067_area6c.bmsmsd", Bmsmsd)
     mapicon = area6c.raw["tiles"]
 
-    # Doors
     # Door005 (Plasma Beam Missile Door)
     mapicon[32]["icons"][0]["icon"] = "doorpowerleft"
 
@@ -253,80 +139,34 @@ def _area6c_icons(editor: PatcherEditor):
     # Door009 (Gravity Suit Missile Door)
     mapicon[149]["icons"][0]["icon"] = "doorpowerleft"
 
-    # Items
-    for tile in range(212):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
-            "icon"
-        ].startswith("item"):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
-
-def _area7_icons(editor: PatcherEditor):
+def _area7_doors(editor: PatcherEditor):
     area7 = editor.get_file("gui/minimaps/c10_samus/s070_area7.bmsmsd", Bmsmsd)
     mapicon = area7.raw["tiles"]
 
-    # Doors
     # Door010 (Pre-Steal Charge Door)
     mapicon[273]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[274]["icons"][0]["icon"] = "doorpowerright"
 
-    for tile in range(351):
-        # Hazardous Tiles
-        if mapicon[tile]["tile_type"] in {"ACID", "ACID_RISE", "ACID_FALL"}:
-            mapicon[tile]["tile_type"] = "NORMAL"
-        # Items
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
-            "icon"
-        ].startswith("item"):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
-
-def _area9_icons(editor: PatcherEditor):
+def _area9_doors(editor: PatcherEditor):
     area9 = editor.get_file("gui/minimaps/c10_samus/s090_area9.bmsmsd", Bmsmsd)
     mapicon = area9.raw["tiles"]
 
-    # Doors
     # Door012 (Chozo Seal Charge Door)
     mapicon[89]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[90]["icons"][0]["icon"] = "doorpowerright"
 
-    for tile in range(387):
-        # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == "ACID":
-            mapicon[tile]["tile_type"] = "NORMAL"
-        # Items
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
-            "icon"
-        ].startswith("item"):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
-
-
-def _area10_icons(editor: PatcherEditor):
-    area10 = editor.get_file("gui/minimaps/c10_samus/s100_area10.bmsmsd", Bmsmsd)
-    mapicon = area10.raw["tiles"]
-
-    # Items
-    for tile in range(339):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
-            "icon"
-        ].startswith("item"):
-            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
-
-
 def update_map_icons(editor: PatcherEditor):
-    _surface_icons(editor)
-    _area1_icons(editor)
-    _area2_icons(editor)
-    _area2b_icons(editor)
-    _area2c_icons(editor)
-    _area3_icons(editor)
-    _area3b_icons(editor)
-    _area3c_icons(editor)
-    _area4_icons(editor)
-    _area5_icons(editor)
-    _area6_icons(editor)
-    _area6b_icons(editor)
-    _area6c_icons(editor)
-    _area7_icons(editor)
-    _area9_icons(editor)
-    _area10_icons(editor)
+    _patch_tiles(ListContainer, editor)
+    _surface_doors(editor)
+    _area1_doors(editor)
+    _area2b_doors(editor)
+    _area2c_doors(editor)
+    _area3_doors(editor)
+    _area4_doors(editor)
+    _area5_doors(editor)
+    _area6_doors(editor)
+    _area6c_doors(editor)
+    _area7_doors(editor)
+    _area9_doors(editor)

--- a/open_samus_returns_rando/specific_patches/map_icons.py
+++ b/open_samus_returns_rando/specific_patches/map_icons.py
@@ -15,10 +15,13 @@ def _surface_icons(editor: PatcherEditor):
     mapicon[57]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[58]["icons"][0]["icon"] = "doorpowerright"
 
-    # Hazardous Tiles
-    for tile in range(89):
+    for tile in range(479):
+        # Hazardous Tiles
         if mapicon[tile]["tile_type"] == 4:
             mapicon[tile]["tile_type"] = 1
+        # Items
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
 def _area1_icons(editor: PatcherEditor):
@@ -40,10 +43,24 @@ def _area1_icons(editor: PatcherEditor):
     # Door016 (Exterior Alpha)
     mapicon[302]["icons"][0]["icon"] = "doorpowerright"
 
-    # Hazardous Tiles
-    for tile in range(52):
+    for tile in range(384):
+        # Hazardous Tiles
         if mapicon[tile]["tile_type"] == 4:
             mapicon[tile]["tile_type"] = 1
+        # Items
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
+    mapicon[158]["icons"][0]["icon"] = "itemenabledheat"
+
+
+def _area2_icons(editor: PatcherEditor):
+    area2 = editor.get_file("gui/minimaps/c10_samus/s020_area2.bmsmsd", Bmsmsd)
+    mapicon = area2.raw["tiles"]
+
+    # Items
+    for tile in range(310):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
 def _area2b_icons(editor: PatcherEditor):
@@ -54,6 +71,12 @@ def _area2b_icons(editor: PatcherEditor):
     # Door008 (Below Wave Beam)
     mapicon[152]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[153]["icons"][0]["clear_condition"] = ""
+
+    # Items
+    for tile in range(160):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
+    mapicon[88]["icons"][0]["icon"] = "itemenabledheat"
 
 
 def _area2c_icons(editor: PatcherEditor):
@@ -68,10 +91,13 @@ def _area2c_icons(editor: PatcherEditor):
     mapicon[32]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[33]["icons"][0]["icon"] = "doorpowerright"
 
-    # Hazardous Tiles
-    for tile in range(37):
+    for tile in range(116):
+        # Hazardous Tiles
         if mapicon[tile]["tile_type"] == 4:
             mapicon[tile]["tile_type"] = 1
+        # Items
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
 def _area3_icons(editor: PatcherEditor):
@@ -86,10 +112,33 @@ def _area3_icons(editor: PatcherEditor):
     mapicon[2]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[3]["icons"][0]["icon"] = "doorpowerright"
 
-    # Hazardous Tiles
-    for tile in range(44):
+    for tile in range(300):
+        # Hazardous Tiles
         if mapicon[tile]["tile_type"] == 4:
             mapicon[tile]["tile_type"] = 1
+        # Items
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
+
+
+def _area3b_icons(editor: PatcherEditor):
+    area3b = editor.get_file("gui/minimaps/c10_samus/s033_area3b.bmsmsd", Bmsmsd)
+    mapicon = area3b.raw["tiles"]
+
+    # Items
+    for tile in range(323):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
+
+
+def _area3c_icons(editor: PatcherEditor):
+    area3c = editor.get_file("gui/minimaps/c10_samus/s036_area3c.bmsmsd", Bmsmsd)
+    mapicon = area3c.raw["tiles"]
+
+    # Items
+    for tile in range(150):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
 def _area4_icons(editor: PatcherEditor):
@@ -108,10 +157,13 @@ def _area4_icons(editor: PatcherEditor):
     mapicon[2]["icons"][1]["icon"] = "doorpowerleft"
     mapicon[3]["icons"][0]["icon"] = "doorpowerright"
 
-    # Hazardous Tiles
-    for tile in range(40):
+    for tile in range(285):
+        # Hazardous Tiles
         if mapicon[tile]["tile_type"] == 4:
             mapicon[tile]["tile_type"] = 1
+        # Items
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
 def _area5_icons(editor: PatcherEditor):
@@ -123,10 +175,11 @@ def _area5_icons(editor: PatcherEditor):
     mapicon[100]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[100]["icons"][0]["icon"] = "doorpowerright"
 
-    # Hazardous Tiles
-    for tile in range(40):
-        if mapicon[tile]["tile_type"] == 4:
-            mapicon[tile]["tile_type"] = 1
+    # Items
+    for tile in range(296):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
+    mapicon[213]["icons"][0]["icon"] = "itemenabledheat"
 
 
 def _area6_icons(editor: PatcherEditor):
@@ -138,10 +191,23 @@ def _area6_icons(editor: PatcherEditor):
     mapicon[14]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[15]["icons"][0]["icon"] = "doorpowerright"
 
-    # Hazardous Tiles
-    for tile in range(42):
+    for tile in range(214):
+        # Hazardous Tiles
         if mapicon[tile]["tile_type"] == 4:
             mapicon[tile]["tile_type"] = 1
+        # Items
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
+
+
+def _area6b_icons(editor: PatcherEditor):
+    area6b = editor.get_file("gui/minimaps/c10_samus/s065_area6b.bmsmsd", Bmsmsd)
+    mapicon = area6b.raw["tiles"]
+
+    # Items
+    for tile in range(290):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
 def _area6c_icons(editor: PatcherEditor):
@@ -158,20 +224,28 @@ def _area6c_icons(editor: PatcherEditor):
     # Door009 (Gravity Suit Missile Door)
     mapicon[149]["icons"][0]["icon"] = "doorpowerleft"
 
+    # Items
+    for tile in range(212):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
+
 
 def _area7_icons(editor: PatcherEditor):
     area7 = editor.get_file("gui/minimaps/c10_samus/s070_area7.bmsmsd", Bmsmsd)
     mapicon = area7.raw["tiles"]
 
     # Doors
-    # Door010 (Chozo Seal Charge Door)
+    # Door010 (Pre-Steal Charge Door)
     mapicon[273]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[274]["icons"][0]["icon"] = "doorpowerright"
 
-    # Hazardous Tiles
-    for tile in range(49):
-        if mapicon[tile]["tile_type"] == 4:
+    for tile in range(351):
+        # Hazardous Tiles
+        if mapicon[tile]["tile_type"] in {4, 8, 12}:
             mapicon[tile]["tile_type"] = 1
+        # Items
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
 def _area9_icons(editor: PatcherEditor):
@@ -179,25 +253,43 @@ def _area9_icons(editor: PatcherEditor):
     mapicon = area9.raw["tiles"]
 
     # Doors
-    # Door012 (Elevator Charge Door)
+    # Door012 (Chozo Seal Charge Door)
     mapicon[89]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[90]["icons"][0]["icon"] = "doorpowerright"
 
-    # Hazardous Tiles
-    for tile in range(61):
+    for tile in range(387):
+        # Hazardous Tiles
         if mapicon[tile]["tile_type"] == 4:
             mapicon[tile]["tile_type"] = 1
+        # Items
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
+
+
+def _area10_icons(editor: PatcherEditor):
+    area10 = editor.get_file("gui/minimaps/c10_samus/s100_area10.bmsmsd", Bmsmsd)
+    mapicon = area10.raw["tiles"]
+
+    # Items
+    for tile in range(339):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+            mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
 def update_map_icons(editor: PatcherEditor):
     _surface_icons(editor)
     _area1_icons(editor)
+    _area2_icons(editor)
     _area2b_icons(editor)
     _area2c_icons(editor)
     _area3_icons(editor)
+    _area3b_icons(editor)
+    _area3c_icons(editor)
     _area4_icons(editor)
     _area5_icons(editor)
     _area6_icons(editor)
+    _area6b_icons(editor)
     _area6c_icons(editor)
     _area7_icons(editor)
     _area9_icons(editor)
+    _area10_icons(editor)

--- a/open_samus_returns_rando/specific_patches/map_icons.py
+++ b/open_samus_returns_rando/specific_patches/map_icons.py
@@ -17,10 +17,14 @@ def _surface_icons(editor: PatcherEditor):
 
     for tile in range(479):
         # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == 4:
-            mapicon[tile]["tile_type"] = 1
+        if mapicon[tile]["tile_type"] == "ACID":
+            mapicon[tile]["tile_type"] = "NORMAL"
         # Items
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and (
+            mapicon[tile]["icons"][0]["icon"].endswith("tank")
+            or mapicon[tile]["icons"][0]["icon"].startswith("itemsphere")
+            or mapicon[tile]["icons"][0]["icon"].startswith("spenergy")
+        ):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
@@ -45,10 +49,12 @@ def _area1_icons(editor: PatcherEditor):
 
     for tile in range(384):
         # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == 4:
-            mapicon[tile]["tile_type"] = 1
+        if mapicon[tile]["tile_type"] == "ACID":
+            mapicon[tile]["tile_type"] = "NORMAL"
         # Items
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
+            "icon"
+        ].startswith("item"):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
     mapicon[158]["icons"][0]["icon"] = "itemenabledheat"
 
@@ -59,7 +65,9 @@ def _area2_icons(editor: PatcherEditor):
 
     # Items
     for tile in range(310):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
+            "icon"
+        ].startswith("item"):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
@@ -74,7 +82,9 @@ def _area2b_icons(editor: PatcherEditor):
 
     # Items
     for tile in range(160):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
+            "icon"
+        ].startswith("item"):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
     mapicon[88]["icons"][0]["icon"] = "itemenabledheat"
 
@@ -93,10 +103,13 @@ def _area2c_icons(editor: PatcherEditor):
 
     for tile in range(116):
         # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == 4:
-            mapicon[tile]["tile_type"] = 1
+        if mapicon[tile]["tile_type"] == "ACID":
+            mapicon[tile]["tile_type"] = "NORMAL"
         # Items
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and (
+            mapicon[tile]["icons"][0]["icon"].startswith("item")
+            or mapicon[tile]["icons"][0]["icon"].startswith("spenergy")
+        ):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
@@ -114,10 +127,13 @@ def _area3_icons(editor: PatcherEditor):
 
     for tile in range(300):
         # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == 4:
-            mapicon[tile]["tile_type"] = 1
+        if mapicon[tile]["tile_type"] == "ACID":
+            mapicon[tile]["tile_type"] = "NORMAL"
         # Items
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and (
+            mapicon[tile]["icons"][0]["icon"].startswith("item")
+            or mapicon[tile]["icons"][0]["icon"].startswith("spenergy")
+        ):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
@@ -127,7 +143,9 @@ def _area3b_icons(editor: PatcherEditor):
 
     # Items
     for tile in range(323):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
+            "icon"
+        ].startswith("item"):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
@@ -137,7 +155,9 @@ def _area3c_icons(editor: PatcherEditor):
 
     # Items
     for tile in range(150):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
+            "icon"
+        ].startswith("item"):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
@@ -159,10 +179,12 @@ def _area4_icons(editor: PatcherEditor):
 
     for tile in range(285):
         # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == 4:
-            mapicon[tile]["tile_type"] = 1
+        if mapicon[tile]["tile_type"] in {"ACID", "ACID_FALL"}:
+            mapicon[tile]["tile_type"] = "NORMAL"
         # Items
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
+            "icon"
+        ].startswith("item"):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
@@ -173,11 +195,13 @@ def _area5_icons(editor: PatcherEditor):
     # Doors
     # Door006 (Elevator Charge Door)
     mapicon[100]["icons"][0]["icon"] = "doorpowerleft"
-    mapicon[100]["icons"][0]["icon"] = "doorpowerright"
+    mapicon[101]["icons"][0]["icon"] = "doorpowerright"
 
     # Items
     for tile in range(296):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
+            "icon"
+        ].startswith("item"):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
     mapicon[213]["icons"][0]["icon"] = "itemenabledheat"
 
@@ -191,12 +215,15 @@ def _area6_icons(editor: PatcherEditor):
     mapicon[14]["icons"][0]["icon"] = "doorpowerleft"
     mapicon[15]["icons"][0]["icon"] = "doorpowerright"
 
-    for tile in range(214):
+    for tile in range(226):
         # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == 4:
-            mapicon[tile]["tile_type"] = 1
+        if mapicon[tile]["tile_type"] == "ACID":
+            mapicon[tile]["tile_type"] = "NORMAL"
         # Items
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and (
+            mapicon[tile]["icons"][0]["icon"].startswith("item")
+            or mapicon[tile]["icons"][0]["icon"].startswith("spenergy")
+        ):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
@@ -206,7 +233,9 @@ def _area6b_icons(editor: PatcherEditor):
 
     # Items
     for tile in range(290):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
+            "icon"
+        ].startswith("item"):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
@@ -226,7 +255,9 @@ def _area6c_icons(editor: PatcherEditor):
 
     # Items
     for tile in range(212):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
+            "icon"
+        ].startswith("item"):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
@@ -241,10 +272,12 @@ def _area7_icons(editor: PatcherEditor):
 
     for tile in range(351):
         # Hazardous Tiles
-        if mapicon[tile]["tile_type"] in {4, 8, 12}:
-            mapicon[tile]["tile_type"] = 1
+        if mapicon[tile]["tile_type"] in {"ACID", "ACID_RISE", "ACID_FALL"}:
+            mapicon[tile]["tile_type"] = "NORMAL"
         # Items
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
+            "icon"
+        ].startswith("item"):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
@@ -259,10 +292,12 @@ def _area9_icons(editor: PatcherEditor):
 
     for tile in range(387):
         # Hazardous Tiles
-        if mapicon[tile]["tile_type"] == 4:
-            mapicon[tile]["tile_type"] = 1
+        if mapicon[tile]["tile_type"] == "ACID":
+            mapicon[tile]["tile_type"] = "NORMAL"
         # Items
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
+            "icon"
+        ].startswith("item"):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 
@@ -272,7 +307,9 @@ def _area10_icons(editor: PatcherEditor):
 
     # Items
     for tile in range(339):
-        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0]["icon"].startswith("item"):
+        if mapicon[tile]["icons"] != ([]) and mapicon[tile]["icons"][0][
+            "icon"
+        ].startswith("item"):
             mapicon[tile]["icons"][0]["icon"] = "itemenabled"
 
 


### PR DESCRIPTION
- Adds new map icon for Baby Metroid pickup
- Changes all item icons to open circles (excluding Aeion Ability Artifacts and Metroids)
- Changes all removed acid tiles to be blue from purple
- Updates door icons to match patcher changes
- Fixes #15 

![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/d10a902b-331e-4bc4-b58c-6c394e817240)
