### PR TITLE
Disable `SetLowModelsVisibility` for samus during boss fights

### DIFF
--- a/open_samus_returns_rando/files/levels/s070_area7.lua
+++ b/open_samus_returns_rando/files/levels/s070_area7.lua
@@ -835,10 +835,10 @@ function s070_area7.OnPlayerDead(_ARG_0_)
   s070_area7.SetLowModelsVisibility(false)
 end
 function s070_area7.SetLowModelsVisibility(_ARG_0_)
-  if Game.GetEntity("Samus") ~= nil then
-    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", not _ARG_0_)
-    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", _ARG_0_)
-  end
+  -- if Game.GetEntity("Samus") ~= nil then
+  --   Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", not _ARG_0_)
+  --   Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", _ARG_0_)
+  -- end
 end
 function s070_area7.LaunchManicMinerBotIntroCutscene()
   if Game.GetEntity("LE_PowerUp_Powerbomb") ~= nil then

--- a/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -289,10 +289,10 @@ function s100_area10.OnPlayerDead(_ARG_0_)
   s100_area10.SetLowModelsVisibility(false)
 end
 function s100_area10.SetLowModelsVisibility(_ARG_0_)
-  if Game.GetEntity("Samus") ~= nil then
-    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", not _ARG_0_)
-    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", _ARG_0_)
-  end
+  -- if Game.GetEntity("Samus") ~= nil then
+  --   Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", not _ARG_0_)
+  --   Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", _ARG_0_)
+  -- end
   if Game.GetEntityFromSpawnPoint("SP_Queen") ~= nil then
     Game.GetEntityFromSpawnPoint("SP_Queen").MODELUPDATER:SetMeshVisible("C01_Head_Ch", not _ARG_0_)
     Game.GetEntityFromSpawnPoint("SP_Queen").MODELUPDATER:SetMeshVisible("C01_Headcombat_Ch", _ARG_0_)

--- a/open_samus_returns_rando/files/levels/s110_surfaceb.lua
+++ b/open_samus_returns_rando/files/levels/s110_surfaceb.lua
@@ -124,10 +124,10 @@ function s110_surfaceb.OnPlayerDead(_ARG_0_)
   s110_surfaceb.SetLowModelsVisibility(false)
 end
 function s110_surfaceb.SetLowModelsVisibility(_ARG_0_)
-  if Game.GetEntity("Samus") ~= nil then
-    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", not _ARG_0_)
-    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", _ARG_0_)
-  end
+  -- if Game.GetEntity("Samus") ~= nil then
+  --   Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", not _ARG_0_)
+  --   Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", _ARG_0_)
+  -- end
   if Game.GetEntityFromSpawnPoint("SP_Ridley") ~= nil then
     Game.GetEntityFromSpawnPoint("SP_Ridley").MODELUPDATER:SetMeshVisible("C01_Body_Ch", not _ARG_0_)
     Game.GetEntityFromSpawnPoint("SP_Ridley").MODELUPDATER:SetMeshVisible("C01_Wings_Ch", not _ARG_0_)


### PR DESCRIPTION
I don't really know what this is doing.
Does Samus has a different model / mesh / hitbox / whatever during the boss fights?

Following the logic during, entering a boss fights makes `C01_Body_Ch` not visible but `C01_Combat_Ch`. If you die or beat the boss, it's flipped again.
And with only varia it looks like there is no `C01_Combat_Ch` and that's why samus is invisible.

Beat ridley with varia and this patch. If it breaks something with gravity suit on, we maybe need to make it check for the suit etc.
