### PR TITLE
Improve reverse a8

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/src/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -273,6 +273,9 @@ function s100_area10.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_
     Game.SetSceneGroupEnabledByName("sg_egg02", true)
     Game.EnableEntity("LE_Baby_Hatchling")
   end
+  if _ARG_2_ == "collision_camera_007" then
+    Blackboard.SetProp("s100_area10", "s100_area10_discovered", "b", true)
+  end
   if _ARG_2_ == "collision_camera_020" then
     s100_area10.fSafeFarPlaneFactor = Game.GetSafeFarPlaneFactor()
     Game.SetSafeFarPlaneFactor(-1)

--- a/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
+++ b/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
@@ -60,6 +60,13 @@ function s110_surfaceb.ElevatorSetTarget(_ARG_0_)
   GUI.ElevatorSetTarget("s000_surface_elevator", false)
 end
 function s110_surfaceb.InitFromBlackboard()
+  if Game.GetEntity("StartPoint0") ~= nil then
+    Game.GetEntity("LE_Elevator_FromArea10_down").USABLE:Activate(false)
+  end
+  bArea10Discovered = Blackboard.GetProp("s100_area10", "s100_area10_discovered")
+  if bArea10Discovered == true then
+    Game.GetEntity("LE_Elevator_FromArea10_down").USABLE:Activate(true)
+  end
 end
 function s110_surfaceb.OnReloaded()
 end

--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -206,7 +206,7 @@
                 },
                 "reverse_area8": {
                     "type": "boolean",
-                    "description": "Enables the elevator from Surface West to Area 8 and removes the wall between the Queen and Baby, allowing access into Area 8 from Surface West.",
+                    "description": "The elevator from Surface West to Area 8 has been changed to be disabled by default. This option enables the elevator and removes the wall between the Queen and Baby, allowing access into Area 8 from Surface West.",
                     "default": false
                 }
             },

--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -206,7 +206,7 @@
                 },
                 "reverse_area8": {
                     "type": "boolean",
-                    "description": "Removes the wall between the Queen and Baby, allowing access into Area 8 from Surface West.",
+                    "description": "Enables the elevator from Surface West to Area 8 and removes the wall between the Queen and Baby, allowing access into Area 8 from Surface West.",
                     "default": false
                 }
             },

--- a/src/open_samus_returns_rando/files/templates/custom_init.lua
+++ b/src/open_samus_returns_rando/files/templates/custom_init.lua
@@ -6,10 +6,6 @@ Init.bRevealMap = TEMPLATE("reveal_map_on_start")
 Init.sStartingScenario = TEMPLATE("starting_scenario")
 Init.sStartingActor = TEMPLATE("starting_actor")
 Init.fEnergyPerTank = TEMPLATE("energy_per_tank")
-Init.tDNAPerArea = TEMPLATE("dna_per_area")
-Init.tScenarioMapping = TEMPLATE("scenario_mapping")
-Init.iNumRandoTextBoxes = TEMPLATE("textbox_count")
-Init.tBoxesSeen = 0
 
 Game.LogWarn(0, "Inventory:")
 for k, v in pairs(Init.tNewGameInventory) do
@@ -25,10 +21,6 @@ function Init.InitGameBlackboard()
     if string.sub(_FORV_3_, 0, 14) == "ITEM_RANDO_DNA" then
       local current_amount = Blackboard.GetProp("PLAYER_INVENTORY", "ITEM_ADN") or 0
       Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_ADN", "f", current_amount + 1)
-    end
-    if string.sub(_FORV_3_, 1, 17) == "ITEM_RESERVE_TANK" then
-      Blackboard.SetProp("GAME", _FORV_3_ .. "_ACTIVE", "b", true)
-      Blackboard.SetProp("GAME", _FORV_3_ .. "_FULL", "b", true)
     end
   end
   Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_METROID_COUNT", "f", 0)
@@ -46,27 +38,13 @@ function Init.InitGameBlackboard()
   Blackboard.SetProp(Game.GetPlayerBlackboardSectionName(), "LevelID", "s", "c10_samus")
   Blackboard.SetProp(Game.GetPlayerBlackboardSectionName(), "ScenarioID", "s", TEMPLATE("starting_scenario"))
   Blackboard.SetProp(Game.GetPlayerBlackboardSectionName(), "StartPoint", "s", TEMPLATE("starting_actor"))
-  Blackboard.SetProp(Game.GetPlayerBlackboardSectionName(), "RANDO_GAME_INITIALIZED", "b", false)
-  Blackboard.SetProp(Game.GetPlayerBlackboardSectionName(), "RANDO_START_TEXT", "b", false)
-  Blackboard.SetProp("s000_surface", "entity_LE_HazarousPool_enabled", "b", false)
-  Blackboard.SetProp("s010_area1", "entity_LE_HazarousPool_enabled", "b", false)
-  Blackboard.SetProp("s028_area2c", "entity_LE_HazarousPool_enabled", "b", false)
-  Blackboard.SetProp("s030_area3", "entity_LE_HazarousPool_enabled", "b", false)
-  Blackboard.SetProp("s040_area4", "entity_LE_HazarousPool_001_enabled", "b", false)
-  Blackboard.SetProp("s040_area4", "entity_LE_HazarousPool_002_enabled", "b", false)
-  Blackboard.SetProp("s060_area6", "entity_LE_HazarousPool_enabled", "b", false)
-  Blackboard.SetProp("s070_area7", "entity_LE_HazarousPool_001_enabled", "b", false)
-  Blackboard.SetProp("s070_area7", "entity_LE_HazarousPool_002_enabled", "b", false)
-  Blackboard.SetProp("s090_area9", "entity_LE_HazarousPool_enabled", "b", false)
 
-  Blackboard.SetProp("s000_surface", "LarvaPresentationPlayed", "b", true)
-  Game.WriteToGameBlackboardSection("PlayedCutscenes", "cutscenes/planetarrival/takes/10/planetarrival10.bmscu", true)
+  Blackboard.SetProp("s100_area10", "s100_area10_discovered",  "b", false)
 
   Game.UnlockAmiiboMenu()
 end
 
 function Init.InitNewGame(arg1, arg2, arg3, arg4, arg4)
-    Init.tBoxesSeen = 0
     Game.LogWarn(0, string.format("Will start Game - %s / %s / %s / %s", tostring(arg1), tostring(arg2), tostring(arg3), tostring(arg4)))
     Game.LoadScenario("c10_samus", Init.sStartingScenario, Init.sStartingActor, "samus", 1)
     if Init.bRevealMap then

--- a/src/open_samus_returns_rando/specific_patches/game_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/game_patches.py
@@ -111,3 +111,8 @@ def _patch_reverse_area8(editor: PatcherEditor, configuration: dict):
         editor.remove_entity(
             {"scenario": "s100_area10", "layer": 9, "actor": "LE_ValveQueen"}
         )
+        # This spawnpoint is unused and will not be used for random start
+        # There might be a more efficient way of disabling the elevator but this works just fine
+        editor.remove_entity(
+            {"scenario": "s110_surfaceb", "layer": 5, "actor": "StartPoint0"}
+        )


### PR DESCRIPTION
Makes the option much more relevant since enabling it prior just removed a single wall. This prevents access entirely, which has bigger logical impact. This does not prevent going to Ridley early from Surface East, however.
![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/f467241c-67e3-4e28-bfb6-e1b15aebb04e)
