### PR TITLE
Fix Area 8 Larvas

### DIFF
--- a/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -146,7 +146,7 @@ function s100_area10.OnLarva_005_Generated(_ARG_0_, _ARG_1_)
   if _ARG_1_ ~= nil and _ARG_1_.AI ~= nil then
     _ARG_1_.AI.bPlaceholder = false
     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Larva_005")
-    _ARG_1_.AI:AddDoorToLock("Door013")
+    -- _ARG_1_.AI:AddDoorToLock("Door013")
     _ARG_1_.AI:AddDoorToLock("Door014")
     _ARG_1_.AI:AddSpawnPointToUnlock("Larva_005")
     _ARG_1_.AI:AddSpawnPointToUnlock("Larva_006")

--- a/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -853,7 +853,7 @@ function s100_area10.LaunchMetroidBossPresentation()
     Game.GetEntity("SG_Larva_001").SPAWNGROUP:EnableSpawnGroup()
   end
   Game.SetSubAreaCurrentSetup("collision_camera_008", "Default", true, true)
-  Game.LaunchCutscene("cutscenes/intrometroidboss/takes/01/intrometroidboss01.bmscu")
+  -- Game.LaunchCutscene("cutscenes/intrometroidboss/takes/01/intrometroidboss01.bmscu")
   if Game.GetEntity("Door010") ~= nil then
     Game.GetEntity("Door010").LIFE:SetInvulnerable(false)
   end
@@ -876,7 +876,7 @@ end
 function s100_area10.StartMetroidCountIncrement()
   Game.MetroidRadarForceStateOnBegin(1, 0.8, true, false)
   s100_area10.iMetroidTotalCountIncrements = 0
-  Game.AddSF(2, "s100_area10.IncrementMetroidTotalCount", "")
+  -- Game.AddSF(2, "s100_area10.IncrementMetroidTotalCount", "")
 end
 function s100_area10.IncrementMetroidTotalCount()
   Game.IncrementMetroidTotalCount(1)

--- a/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -74,6 +74,7 @@ end
 function s100_area10.InitFromBlackboard()
   Scenario.WriteToBlackboard("firstTimeMetroidHatchlingIntroPlayed", "b", true)
   Game.DisableEntity("LE_Baby_Hatchling")
+  Game.DisableTrigger("TG_MetroidRadar")
   if Game.GetEntity("LE_ValveQueen") ~= nil then
     if Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") ~= nil and s100_area10.iNumMetroids == Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") then
       Game.GetEntity("LE_ValveQueen").MODELUPDATER:SetMeshVisible("Valve", false)
@@ -137,7 +138,7 @@ function s100_area10.OnLarva_004_Generated(_ARG_0_, _ARG_1_)
     _ARG_1_.AI.bPlaceholder = false
     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Larva_004")
     _ARG_1_.AI:AddDoorToLock("Door012")
-    _ARG_1_.AI:AddDoorToLock("Door013")
+    -- _ARG_1_.AI:AddDoorToLock("Door013")
     _ARG_1_.AI:AddSpawnPointToUnlock("Larva_003")
     _ARG_1_.AI:AddSpawnPointToUnlock("Larva_004")
   end
@@ -146,7 +147,7 @@ function s100_area10.OnLarva_005_Generated(_ARG_0_, _ARG_1_)
   if _ARG_1_ ~= nil and _ARG_1_.AI ~= nil then
     _ARG_1_.AI.bPlaceholder = false
     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Larva_005")
-    -- _ARG_1_.AI:AddDoorToLock("Door013")
+    _ARG_1_.AI:AddDoorToLock("Door013")
     _ARG_1_.AI:AddDoorToLock("Door014")
     _ARG_1_.AI:AddSpawnPointToUnlock("Larva_005")
     _ARG_1_.AI:AddSpawnPointToUnlock("Larva_006")
@@ -848,7 +849,7 @@ function s100_area10.LaunchMetroidBossPresentation()
   Game.DisableTrigger("TG_Intro_Larva")
   -- Game.HUDAvailabilityGoOff(false, true, false, false)
   Game.SetIgnoreHUDAvailabilityActivationByAbilityComponent(true)
-  Game.AddSF(1, "s100_area10.StartMetroidCountIncrement", "")
+  -- Game.AddSF(1, "s100_area10.StartMetroidCountIncrement", "")
   if Game.GetEntity("SG_Larva_001") ~= nil then
     Game.GetEntity("SG_Larva_001").SPAWNGROUP:EnableSpawnGroup()
   end
@@ -864,7 +865,7 @@ end
 function s100_area10.LaunchMetroidBossPresentationCutsceneEnd()
   Game.HUDAvailabilityGoOn()
   Game.SetIgnoreHUDAvailabilityActivationByAbilityComponent(false)
-  -- Scenario.WriteToBlackboard("MetroidDiscovered", "b", true)
+  Scenario.WriteToBlackboard("MetroidDiscovered", "b", true)
   Game.AddSF(2.25, "Game.MetroidRadarForceStateOnEnd", "")
 end
 function s100_area10.OnEnter_ChangeCamera_IntroLarva()
@@ -876,7 +877,7 @@ end
 function s100_area10.StartMetroidCountIncrement()
   Game.MetroidRadarForceStateOnBegin(1, 0.8, true, false)
   s100_area10.iMetroidTotalCountIncrements = 0
-  -- Game.AddSF(2, "s100_area10.IncrementMetroidTotalCount", "")
+  Game.AddSF(2, "s100_area10.IncrementMetroidTotalCount", "")
 end
 function s100_area10.IncrementMetroidTotalCount()
   Game.IncrementMetroidTotalCount(1)

--- a/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -846,7 +846,7 @@ function s100_area10.LaunchMetroidBossPresentation()
   Game.DelSF("s100_area10.ProcessMetroidRadarDistance")
   Game.DisableTrigger("TG_MetroidRadar")
   Game.DisableTrigger("TG_Intro_Larva")
-  Game.HUDAvailabilityGoOff(false, true, false, false)
+  -- Game.HUDAvailabilityGoOff(false, true, false, false)
   Game.SetIgnoreHUDAvailabilityActivationByAbilityComponent(true)
   Game.AddSF(1, "s100_area10.StartMetroidCountIncrement", "")
   if Game.GetEntity("SG_Larva_001") ~= nil then
@@ -864,7 +864,7 @@ end
 function s100_area10.LaunchMetroidBossPresentationCutsceneEnd()
   Game.HUDAvailabilityGoOn()
   Game.SetIgnoreHUDAvailabilityActivationByAbilityComponent(false)
-  Scenario.WriteToBlackboard("MetroidDiscovered", "b", true)
+  -- Scenario.WriteToBlackboard("MetroidDiscovered", "b", true)
   Game.AddSF(2.25, "Game.MetroidRadarForceStateOnEnd", "")
 end
 function s100_area10.OnEnter_ChangeCamera_IntroLarva()

--- a/open_samus_returns_rando/files/templates/custom_init.lua
+++ b/open_samus_returns_rando/files/templates/custom_init.lua
@@ -53,6 +53,7 @@ function Init.InitGameBlackboard()
   Blackboard.SetProp("s000_surface", "LarvaPresentationPlayed", "b", true)
   Game.WriteToGameBlackboardSection("PlayedCutscenes", "cutscenes/planetarrival/takes/10/planetarrival10.bmscu", true)
 
+  Blackboard.SetProp("s100_area10", "MetroidDiscovered", "b", true)
 
   Game.UnlockAmiiboMenu()
 end

--- a/open_samus_returns_rando/files/templates/custom_init.lua
+++ b/open_samus_returns_rando/files/templates/custom_init.lua
@@ -53,8 +53,6 @@ function Init.InitGameBlackboard()
   Blackboard.SetProp("s000_surface", "LarvaPresentationPlayed", "b", true)
   Game.WriteToGameBlackboardSection("PlayedCutscenes", "cutscenes/planetarrival/takes/10/planetarrival10.bmscu", true)
 
-  Blackboard.SetProp("s100_area10", "MetroidDiscovered", "b", true)
-
   Game.UnlockAmiiboMenu()
 end
 

--- a/open_samus_returns_rando/samus_returns_patcher.py
+++ b/open_samus_returns_rando/samus_returns_patcher.py
@@ -53,7 +53,7 @@ def create_custom_init(configuration: dict) -> str:
         "ITEM_WEAPON_SUPER_MISSILE_MAX": 0,
         "ITEM_WEAPON_POWER_BOMB_MAX": 0,
         "ITEM_METROID_COUNT": 0,
-        "ITEM_METROID_TOTAL_COUNT": 40,
+        "ITEM_METROID_TOTAL_COUNT": 50,
     }
     final_inventory.update(inventory)
 


### PR DESCRIPTION
- Removes the Larva intro cutscene
- Adds 10 Metroids to the Metroid counter (should this only be added on when in Area 8? Would this cause confusion in routing?)
- Prevents a door from locking if entering the room with Larva_005 to remove a softlock  