### PR TITLE
Use low poly model if player has gravity suit

### DIFF
--- a/open_samus_returns_rando/files/levels/s070_area7.lua
+++ b/open_samus_returns_rando/files/levels/s070_area7.lua
@@ -835,10 +835,13 @@ function s070_area7.OnPlayerDead(_ARG_0_)
   s070_area7.SetLowModelsVisibility(false)
 end
 function s070_area7.SetLowModelsVisibility(_ARG_0_)
-  -- if Game.GetEntity("Samus") ~= nil then
-  --   Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", not _ARG_0_)
-  --   Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", _ARG_0_)
-  -- end
+  if _ARG_0_ and Game.GetEntity("Samus") ~= nil and Game.GetItemAmount(Game.GetPlayerName(), "ITEM_GRAVITY_SUIT") == 1 then
+    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", false)
+    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", true)
+  elseif not _ARG_0_ and Game.GetEntity("Samus") ~= nil then
+    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", true)
+    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", false)
+  end
 end
 function s070_area7.LaunchManicMinerBotIntroCutscene()
   if Game.GetEntity("LE_PowerUp_Powerbomb") ~= nil then

--- a/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -290,10 +290,13 @@ function s100_area10.OnPlayerDead(_ARG_0_)
   s100_area10.SetLowModelsVisibility(false)
 end
 function s100_area10.SetLowModelsVisibility(_ARG_0_)
-  -- if Game.GetEntity("Samus") ~= nil then
-  --   Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", not _ARG_0_)
-  --   Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", _ARG_0_)
-  -- end
+  if _ARG_0_ and Game.GetEntity("Samus") ~= nil and Game.GetItemAmount(Game.GetPlayerName(), "ITEM_GRAVITY_SUIT") == 1 then
+    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", false)
+    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", true)
+  elseif not _ARG_0_ and Game.GetEntity("Samus") ~= nil then
+    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", true)
+    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", false)
+  end
   if Game.GetEntityFromSpawnPoint("SP_Queen") ~= nil then
     Game.GetEntityFromSpawnPoint("SP_Queen").MODELUPDATER:SetMeshVisible("C01_Head_Ch", not _ARG_0_)
     Game.GetEntityFromSpawnPoint("SP_Queen").MODELUPDATER:SetMeshVisible("C01_Headcombat_Ch", _ARG_0_)

--- a/open_samus_returns_rando/files/levels/s110_surfaceb.lua
+++ b/open_samus_returns_rando/files/levels/s110_surfaceb.lua
@@ -124,10 +124,13 @@ function s110_surfaceb.OnPlayerDead(_ARG_0_)
   s110_surfaceb.SetLowModelsVisibility(false)
 end
 function s110_surfaceb.SetLowModelsVisibility(_ARG_0_)
-  -- if Game.GetEntity("Samus") ~= nil then
-  --   Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", not _ARG_0_)
-  --   Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", _ARG_0_)
-  -- end
+  if _ARG_0_ and Game.GetEntity("Samus") ~= nil and Game.GetItemAmount(Game.GetPlayerName(), "ITEM_GRAVITY_SUIT") == 1 then
+    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", false)
+    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", true)
+  elseif not _ARG_0_ and Game.GetEntity("Samus") ~= nil then
+    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Body_Ch", true)
+    Game.GetEntity("Samus").MODELUPDATER:SetMeshVisible("C01_Combat_Ch", false)
+  end
   if Game.GetEntityFromSpawnPoint("SP_Ridley") ~= nil then
     Game.GetEntityFromSpawnPoint("SP_Ridley").MODELUPDATER:SetMeshVisible("C01_Body_Ch", not _ARG_0_)
     Game.GetEntityFromSpawnPoint("SP_Ridley").MODELUPDATER:SetMeshVisible("C01_Wings_Ch", not _ARG_0_)


### PR DESCRIPTION
This activates the low poly model for fights if the player has gravity suit.
It's not possible for other suits because there are no different models and samus would be invisible.