### PR TITLE
Empty the static dict when start patching.

### DIFF
--- a/src/open_samus_returns_rando/pickups/pickup.py
+++ b/src/open_samus_returns_rando/pickups/pickup.py
@@ -285,6 +285,7 @@ def count_dna(lua_scripts: LuaEditor, pickup_object: BasePickup):
         lua_scripts.add_dna(scenario)
 
 def patch_pickups(editor: PatcherEditor, lua_scripts: LuaEditor, pickups_config: list[dict], configuration: dict):
+    ActorPickup._bmsad_dict = {}
     editor.add_new_asset("actors/items/randomizer_powerup/scripts/randomizer_powerup.lc", b'', [])
     editor.add_new_asset("actors/scripts/metroid.lc", b'', [])
     ensure_base_models(editor)


### PR DESCRIPTION
The dict keeps being filled if you try to make more than one export in a row via randovania because it is static.
So, I clear it before loop through the pickups.