### PR TITLE
Support displaying seed hash when making a file

### DIFF
--- a/open_samus_returns_rando/files/schema.json
+++ b/open_samus_returns_rando/files/schema.json
@@ -231,6 +231,12 @@
             },
             "default": []
         },
+        "text_patches": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
         "spoiler_log": {
             "type": "object",
             "additionalProperties": {

--- a/open_samus_returns_rando/samus_returns_patcher.py
+++ b/open_samus_returns_rando/samus_returns_patcher.py
@@ -11,7 +11,7 @@ from open_samus_returns_rando.logger import LOG
 from open_samus_returns_rando.lua_editor import LuaEditor
 from open_samus_returns_rando.misc_patches.credits import patch_credits
 from open_samus_returns_rando.misc_patches.exefs import DSPatch
-from open_samus_returns_rando.misc_patches.text_patches import patch_pb_status
+from open_samus_returns_rando.misc_patches.text_patches import apply_text_patches, patch_pb_status
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 from open_samus_returns_rando.pickup import patch_pickups
 from open_samus_returns_rando.specific_patches import game_patches
@@ -85,6 +85,8 @@ def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
     game_patches.apply_game_patches(editor, configuration.get("game_patches", {}))
 
     # Text patches
+    if "text_patches" in configuration:
+        apply_text_patches(editor, configuration["text_patches"])
     patch_credits(editor, configuration["spoiler_log"])
     patch_pb_status(editor)
 


### PR DESCRIPTION
Replaces `A new file will be created.` and `Current data will be erased.|Start a new game in {difficulty} mode?` with the seed hash. There is probably a way to add the hash to the title screen, but that would require creating new text since the copyright is actually an image and not text.

![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/79c0d216-4f2d-40c7-978e-4170dc2c7bcc)
![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/9cea3d4e-c3c6-4a2d-9267-d7ab73f7118b)
