### PR TITLE
Support enabling/shuffling amiibo Reserve Tanks

### DIFF
--- a/src/open_samus_returns_rando/files/randomizer_powerup.lua
+++ b/src/open_samus_returns_rando/files/randomizer_powerup.lua
@@ -296,3 +296,27 @@ function RandomizerPhaseDisplacement.OnPickedUp(progression)
     RandomizerPowerup.OnPickedUp(progression)
     Player.SetAbilityUnlocked("PhaseDisplacement", true)
 end
+
+RandomizerReserveTankE = {}
+setmetatable(RandomizerReserveTankL, {__index = RandomizerPowerup})
+function RandomizerReserveTankL.OnPickedUp(progression)
+    RandomizerPowerup.OnPickedUp(progression)
+    Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_LIFE_ACTIVE", "b", true)
+    Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_LIFE_FULL", "b", true)
+end
+
+RandomizerReserveTankM = {}
+setmetatable(RandomizerReserveTankM, {__index = RandomizerPowerup})
+function RandomizerReserveTankM.OnPickedUp(progression)
+    RandomizerPowerup.OnPickedUp(progression)
+    Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_MISSILE_ACTIVE", "b", true)
+    Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_MISSILE_FULL", "b", true)
+end
+
+RandomizerReserveTankA = {}
+setmetatable(RandomizerReserveTankSE, {__index = RandomizerPowerup})
+function RandomizerReserveTankSE.OnPickedUp(progression)
+    RandomizerPowerup.OnPickedUp(progression)
+    Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_SPECIAL_ENERGY_ACTIVE", "b", true)
+    Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_SPECIAL_ENERGY_FULL", "b", true)
+end

--- a/src/open_samus_returns_rando/files/randomizer_powerup.lua
+++ b/src/open_samus_returns_rando/files/randomizer_powerup.lua
@@ -303,6 +303,8 @@ function RandomizerReserveTankE.OnPickedUp(progression)
     RandomizerPowerup.OnPickedUp(progression)
     Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_LIFE_ACTIVE", "b", true)
     Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_LIFE_FULL", "b", true)
+    Game.AddSF(0.0, "Game.HUDIdleScreenGo", "")
+    Game.AddSF(0.5, "Game.HUDIdleScreenLeave", "")
 end
 
 RandomizerReserveTankM = {}
@@ -311,6 +313,8 @@ function RandomizerReserveTankM.OnPickedUp(progression)
     RandomizerPowerup.OnPickedUp(progression)
     Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_MISSILE_ACTIVE", "b", true)
     Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_MISSILE_FULL", "b", true)
+    Game.AddSF(0.0, "Game.HUDIdleScreenGo", "")
+    Game.AddSF(0.5, "Game.HUDIdleScreenLeave", "")
 end
 
 RandomizerReserveTankA = {}
@@ -319,4 +323,6 @@ function RandomizerReserveTankA.OnPickedUp(progression)
     RandomizerPowerup.OnPickedUp(progression)
     Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_SPECIAL_ENERGY_ACTIVE", "b", true)
     Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_SPECIAL_ENERGY_FULL", "b", true)
+    Game.AddSF(0.0, "Game.HUDIdleScreenGo", "")
+    Game.AddSF(0.5, "Game.HUDIdleScreenLeave", "")
 end

--- a/src/open_samus_returns_rando/files/randomizer_powerup.lua
+++ b/src/open_samus_returns_rando/files/randomizer_powerup.lua
@@ -298,8 +298,8 @@ function RandomizerPhaseDisplacement.OnPickedUp(progression)
 end
 
 RandomizerReserveTankE = {}
-setmetatable(RandomizerReserveTankL, {__index = RandomizerPowerup})
-function RandomizerReserveTankL.OnPickedUp(progression)
+setmetatable(RandomizerReserveTankE, {__index = RandomizerPowerup})
+function RandomizerReserveTankE.OnPickedUp(progression)
     RandomizerPowerup.OnPickedUp(progression)
     Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_LIFE_ACTIVE", "b", true)
     Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_LIFE_FULL", "b", true)
@@ -314,8 +314,8 @@ function RandomizerReserveTankM.OnPickedUp(progression)
 end
 
 RandomizerReserveTankA = {}
-setmetatable(RandomizerReserveTankSE, {__index = RandomizerPowerup})
-function RandomizerReserveTankSE.OnPickedUp(progression)
+setmetatable(RandomizerReserveTankA, {__index = RandomizerPowerup})
+function RandomizerReserveTankA.OnPickedUp(progression)
     RandomizerPowerup.OnPickedUp(progression)
     Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_SPECIAL_ENERGY_ACTIVE", "b", true)
     Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_SPECIAL_ENERGY_FULL", "b", true)

--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -399,7 +399,10 @@
                 "ITEM_RANDO_DNA_36",
                 "ITEM_RANDO_DNA_37",
                 "ITEM_RANDO_DNA_38",
-                "ITEM_RANDO_DNA_39"
+                "ITEM_RANDO_DNA_39",
+                "ITEM_RESERVE_TANK_LIFE",
+                "ITEM_RESERVE_TANK_MISSILE",
+                "ITEM_RESERVE_TANK_SPECIAL_ENERGY"
             ]
         },
         "item": {

--- a/src/open_samus_returns_rando/files/templates/custom_init.lua
+++ b/src/open_samus_returns_rando/files/templates/custom_init.lua
@@ -24,6 +24,10 @@ function Init.InitGameBlackboard()
       local current_amount = Blackboard.GetProp("PLAYER_INVENTORY", "ITEM_ADN") or 0
       Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_ADN", "f", current_amount + 1)
     end
+    if string.sub(_FORV_3_, 1, 17) == "ITEM_RESERVE_TANK" then
+      Blackboard.SetProp("GAME", _FORV_3_ .. "_ACTIVE", "b", true)
+      Blackboard.SetProp("GAME", _FORV_3_ .. "_FULL", "b", true)
+    end
   end
   Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_METROID_COUNT", "f", 0)
   Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_CURRENT_LIFE", "f", Init.tNewGameInventory.ITEM_MAX_LIFE)

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -27,6 +27,9 @@ SPECIFIC_CLASSES = {
     "ITEM_SPECIAL_ENERGY_ENERGY_WAVE": "RandomizerEnergyWave",
     "ITEM_SPECIAL_ENERGY_PHASE_DISPLACEMENT": "RandomizerPhaseDisplacement",
     "ITEM_ENERGY_TANKS": "RandomizerEnergyTank",
+    "ITEM_RESERVE_TANK_LIFE": "RandomizerReserveTankE",
+    "ITEM_RESERVE_TANK_MISSILE": "RandomizerReserveTankM",
+    "ITEM_RESERVE_TANK_SPECIAL_ENERGY": "RandomizerReserveTankA",
 }
 
 SPECIFIC_SOUNDS = {

--- a/src/open_samus_returns_rando/pickups/pickup.py
+++ b/src/open_samus_returns_rando/pickups/pickup.py
@@ -12,6 +12,12 @@ from open_samus_returns_rando.lua_editor import LuaEditor
 from open_samus_returns_rando.patcher_editor import PatcherEditor, path_for_level
 from open_samus_returns_rando.pickups.model_data import get_data
 
+RESERVE_TANK_ITEMS = {
+    "ITEM_RESERVE_TANK_LIFE",
+    "ITEM_RESERVE_TANK_MISSILE",
+    "ITEM_RESERVE_TANK_SPECIAL_ENERGY",
+}
+
 TANK_MODELS = {
     "item_energytank",
     "item_senergytank",
@@ -124,6 +130,7 @@ class ActorPickup(BasePickup):
 
     def patch_model(self, model_names: list[str], bmsad: dict) -> None:
         MODELUPDATER = bmsad["components"]["MODELUPDATER"]
+        item_id: str = self.pickup["resources"][0][0]["item_id"]
         model_name = model_names[0]
         y_offset = MODEL_TO_OFFSET.get(model_name, 20)
         if len(model_names) == 1:
@@ -143,7 +150,15 @@ class ActorPickup(BasePickup):
                     MODELUPDATER["functions"][0]["params"]["Param2"]["value"] = energytank_bcmdl
                 else:
                     MODELUPDATER["functions"][0]["params"].pop("Param2")
-                bmsad["components"].pop("FX")
+                # Placeholder until custom models/textures are made
+                if item_id in RESERVE_TANK_ITEMS:
+                    fx_create_and_link["Param1"]["value"] = "spenergycloud"
+                    fx_create_and_link["Param2"]["value"] = "actors/props/spenergycloud/fx/specialenergystatue.bcptl"
+                    fx_create_and_link["Param8"]["value"] = 50
+                    fx_create_and_link["Param9"]["value"] = 10
+                    fx_create_and_link["Param13"]["value"] = True
+                else:
+                    bmsad["components"].pop("FX")
             # aeion abilities
             elif model_name in AEION_MODELS:
                 fx_create_and_link["Param8"]["value"] = y_offset
@@ -167,6 +182,11 @@ class ActorPickup(BasePickup):
                 fx_create_and_link["Param8"]["value"] = y_offset
                 fx_create_and_link["Param1"]["value"] = "leak"
                 fx_create_and_link["Param2"]["value"] = "actors/items/adn/fx/adnleak.bcptl"
+                fx_create_and_link["Param13"]["value"] = True
+            elif model_name == "itemsphere":
+                fx_create_and_link["Param1"]["value"] = "itemsphere"
+                fx_create_and_link["Param2"]["value"] = "actors/items/itemsphere/fx/itemsphereparts.bcptl"
+                fx_create_and_link["Param8"]["value"] = 20
                 fx_create_and_link["Param13"]["value"] = True
             else:
                 bmsad["components"].pop("FX")


### PR DESCRIPTION
Adds the three amiibo Reserve Tanks as items, and allows them to be shuffled. They currently use their respective tank model in game and the Aeion Refill Orb FX until we have custom models/textures. Fixes #22 

Current issue is that the HUD doesn't update unless the bottom screen changes (pause, idle screen). The tanks still work but there is no game pause when the reserve is activated and it just happens, which is jarring. Ideally, a proper fix is implemented before merging, but not mandatory.

This PR also adds missing FX for itemspheres.

**Energy Reserve Tank**
![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/dd4b607b-d4a7-4a7b-9af3-68b7831d53d4)
![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/395e4d12-c708-4e28-b542-15a1f90ec7a7)

https://github.com/randovania/open-samus-returns-rando/assets/38679103/86eed34b-cf78-4f16-8824-eca19fd2afe7

**Missile Reserve Tank**
![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/42a4e5d9-e9c2-4658-9cd0-7fff89db0c40)
![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/ae3cbbaa-ed1c-44f8-9774-dbac542eacd6)

https://github.com/randovania/open-samus-returns-rando/assets/38679103/b1290105-b7f3-4e50-bc11-edcb4b2c59d3

**Aeion Reserve Tank**
![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/cde6a490-9e33-41e7-8265-6064d649731e)
![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/0b43073f-d7ed-411c-a7f3-6fcc74c3afbf)

https://github.com/randovania/open-samus-returns-rando/assets/38679103/ca676c14-e7cb-4b8b-9209-cac761d649de
