### PR TITLE
Change Save Screw Blocks in A7 from Screw to be Shot

### DIFF
--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -1,3 +1,4 @@
+from mercury_engine_data_structures.formats import Bmsbk
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 MULTI_ROOM_GAMMAS = [
@@ -63,8 +64,17 @@ def remove_area7_grapple_block(editor: PatcherEditor):
     )
 
 
+def patch_a7_save_screw_blocks(editor: PatcherEditor):
+    # Crumble blocks after Scan Pulse
+    area7 = editor.get_file(
+        "maps/levels/c10_samus/s090_area9/s090_area9.bmsbk", Bmsbk
+    )
+    area7.raw["block_groups"][56]["types"][0]["block_type"] = "power_beam"
+
+
 def apply_static_fixes(editor: PatcherEditor):
     patch_multi_room_gammas(editor)
     patch_pickup_rotation(editor)
     patch_pickup_position(editor)
     remove_area7_grapple_block(editor)
+    patch_a7_save_screw_blocks(editor)

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -65,7 +65,6 @@ def remove_area7_grapple_block(editor: PatcherEditor):
 
 
 def patch_a7_save_screw_blocks(editor: PatcherEditor):
-    # Crumble blocks after Scan Pulse
     area7 = editor.get_file(
         "maps/levels/c10_samus/s090_area9/s090_area9.bmsbk", Bmsbk
     )


### PR DESCRIPTION
Prevents an unnecessary and pointless softlock while keeping the logic intact

![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/3839cef1-e9ce-4e74-a90a-8717225cc47e)
