### PR TITLE
Completely prevent accessing Ridley early

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
+++ b/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
@@ -555,7 +555,7 @@ function s110_surfaceb.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_
   Game.SetScenarioItemEnabledByName("ray01", false)
   Game.SetSceneGroupEnabledByName("sg_debris02", false)
   Game.SetSceneGroupEnabledByName("sg_debris03", false)
-  if _ARG_0_ == "collision_camera_017" and _ARG_2_ == "collision_camera_000" and Game.GetItemAmount(Game.GetPlayerName(), "ITEM_ADN") < 39 then
+  if _ARG_2_ == "collision_camera_000" and Game.GetItemAmount(Game.GetPlayerName(), "ITEM_ADN") < 39 then
     Game.ForceConvertToSamus()
     Scenario.LoadNewScenario("s000_surface", "")
     Game.GetPlayer().vPos = V3D(-22800, 4450, 0)


### PR DESCRIPTION
Fixes being able to bypass the DNA check if entering the Landing Site from a different cc