### PR TITLE
Disable damage when Metroid dies

### DIFF
--- a/src/open_samus_returns_rando/specific_patches/metroid_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/metroid_patches.py
@@ -44,10 +44,8 @@ def _patch_metroids(editor: PatcherEditor):
         # weird case where some fields are defined two times
         if type(ai_component["fields"]) == ListContainer:
             ai_component["fields"][94]["value"]["value"] = False
-            ai_component["fields"][95]["value"]["value"] = False
         else:
             ai_component["fields"]["bRemovePlayerInputOnDeath"]["value"] = False
-            ai_component["fields"]["bSetPlayerInvulnerableWithReactionOnDeath"]["value"] = False
 
         # script component defines in which lua file the function names from "args" can be found
         script_component = metroid_bmsad.raw["components"]["SCRIPT"]


### PR DESCRIPTION
Reenables the invulnerability field when defeating a Metroid. Fixes a softlock that occurs when dying the same time the item popup appears.

https://github.com/randovania/open-samus-returns-rando/assets/38679103/25b7e592-14d7-4bc5-9e3e-545d44c89e84

