### PR TITLE
Improve disabling liquid actors if collecting Gravity

### DIFF
--- a/src/open_samus_returns_rando/files/templates/randomizer_powerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizer_powerup.lua
@@ -73,11 +73,9 @@ if RandomizerPowerup == nil then
             -- both loops cover repeated/similar actor names that are shared across scenarios
             if scenario ~= "s000_surface" and scenario ~= "s010_area1" and scenario ~= "s110_surfaceb" then
                 local waterPrefixes = {"TG_Water_", "TG_SP_Water_"}
-                local waterNumbers = {"001", "002", "003", "004", "005", "006", "007", "008", "009", "010", "011", "012",
-                    "013", "014", "015", "016", "017", "018", "019"}
                 for i = 1, 2 do
                     for j = 1, 19 do
-                        local water = Game.GetEntity(waterPrefixes[i] .. waterNumbers[j])
+                        local water = Game.GetEntity(waterPrefixes[i] .. string.format("%03d", j))
                         if water ~= nil and water.TRIGGER:IsPlayerInside() == true then
                             water.TRIGGER:DisableTrigger()
                             water.TRIGGER:EnableTrigger()
@@ -89,8 +87,7 @@ if RandomizerPowerup == nil then
                 local lavaScenarios = {"s020_area2", "s033_area3b", "s036_area3c", "s040_area4", "s050_area5"}
                 if scenario == lavaScenarios[i] then
                     for j = 1, 5 do
-                        local lavaNumbers = {"001", "002", "003", "004", "005"}
-                        lava = Game.GetEntity("TG_Lava_" .. lavaNumbers[j])
+                        lava = Game.GetEntity("TG_Lava_" .. string.format("%03d", j))
                         if lava ~= nil and lava.TRIGGER:IsPlayerInside() == true then
                             lava.TRIGGER:DisableTrigger()
                             lava.TRIGGER:EnableTrigger()
@@ -100,29 +97,22 @@ if RandomizerPowerup == nil then
             end
             -- individual scenarios are listed if they have unique actor names
             local liquids = {}
-            local arrayLength = 0
             if scenario == "s000_surface" then
                 liquids = {"TG_Water", "TG_Water001"}
-                arrayLength = 2
             elseif scenario == "s010_area1" then
                 liquids = {"HazardousPuddle_001", "Lava_Trigger_001", "TG_Water_001", "Water_Trigger_002",
                 "Water_Trigger_008", "Water_Trigger_009", "Water_Trigger_010", "Water_Trigger_011"}
-                arrayLength = 8
             elseif scenario == "s036_area3c" then
                 liquids = {"TG_Water002", "TG_Water003", "TG_LS_Water004"}
-                arrayLength = 3
             elseif scenario == "s040_area4" then
                 liquids = {"TG_HazardousPuddle_001", "TG_HazardousPuddle_002", "TG_HazardousPuddle_003",
                     "TG_HazardousPuddle_004", "TG_HazardousPuddle_005"}
-                arrayLength = 5
             elseif scenario == "s065_area6b" then
                 liquids = {"TG_LS_Water_001"}
-                arrayLength = 1
             elseif scenario == "s070_area7" then
                 liquids = {"TG_Damage_Hazardous_001", "TG_Damage_Hazardous_002"}
-                arrayLength = 1
             end
-            for i = 1, arrayLength do
+            for i = 1, #liquids do
                 local liquid = Game.GetEntity(liquids[i])
                 if liquid.TRIGGER:IsPlayerInside() == true then
                     Game.GetEntity(liquid[i]).TRIGGER:DisableTrigger()

--- a/src/open_samus_returns_rando/files/templates/randomizer_powerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizer_powerup.lua
@@ -267,10 +267,10 @@ if RandomizerPowerup == nil then
     function RandomizerSuit.OnPickedUp(progression)
         RandomizerPowerup.DisableLiquids()
         RandomizerPowerup.OnPickedUp(progression)
-        if Game.GetEntity("Samus").MODELUPDATER.sModelAlias == "Default" then
-            Game.GetEntity("Samus").MODELUPDATER.sModelAlias = "Varia"
-        else
+        if Game.GetItemAmount(Game.GetPlayerName(), "ITEM_GRAVITY_SUIT") > 0 then
             Game.GetEntity("Samus").MODELUPDATER.sModelAlias = "Gravity"
+        else
+            Game.GetEntity("Samus").MODELUPDATER.sModelAlias = "Varia"
         end
         Game.GetPlayer():StopEntityLoopWithFade("actors/samus/damage_alarm.wav", 0.6)
         RandomizerPowerup.EnableLiquids()


### PR DESCRIPTION
- The suit model now properly updates when suits are not progressive (Power -> Gravity now uses Gravity model instead of Varia)
- The check for enabling/disabling triggers has been overhauled
  - Adds in some triggers that were unaccounted for
  - Combines both functions into a more streamlined one
  - Checks if Samus is inside a trigger and only disables that specific one instead of disabling all of them in the scenario
  - Accounts for all liquids (acid, lava, water) regardless if they normally have an item or not
    - This only applies to Multiworld, as it could be possible to receive Gravity while in one of these triggers which would force the player to reload their save
- Removes unused/uncessary function calls elsewhere