### PR TITLE
Use less obstructive fx for Reserve Tanks

### DIFF
--- a/src/open_samus_returns_rando/pickups/pickup.py
+++ b/src/open_samus_returns_rando/pickups/pickup.py
@@ -156,7 +156,7 @@ class ActorPickup(BasePickup):
                 if item_id in RESERVE_TANK_ITEMS:
                     fx_create_and_link["Param1"]["value"] = "spinattack"
                     fx_create_and_link["Param2"]["value"] = "actors/characters/samus/fx/spinattack.bcptl"
-                    fx_create_and_link["Param8"]["value"] = 50
+                    fx_create_and_link["Param8"]["value"] = 55
                     fx_create_and_link["Param13"]["value"] = True
                 else:
                     bmsad["components"].pop("FX")

--- a/src/open_samus_returns_rando/pickups/pickup.py
+++ b/src/open_samus_returns_rando/pickups/pickup.py
@@ -154,10 +154,9 @@ class ActorPickup(BasePickup):
                     MODELUPDATER["functions"][0]["params"].pop("Param2")
                 # Placeholder until custom models/textures are made
                 if item_id in RESERVE_TANK_ITEMS:
-                    fx_create_and_link["Param1"]["value"] = "spenergycloud"
-                    fx_create_and_link["Param2"]["value"] = "actors/props/spenergycloud/fx/specialenergystatue.bcptl"
+                    fx_create_and_link["Param1"]["value"] = "spinattack"
+                    fx_create_and_link["Param2"]["value"] = "actors/characters/samus/fx/spinattack.bcptl"
                     fx_create_and_link["Param8"]["value"] = 50
-                    fx_create_and_link["Param9"]["value"] = 10
                     fx_create_and_link["Param13"]["value"] = True
                 else:
                     bmsad["components"].pop("FX")


### PR DESCRIPTION
`spinattack.bcptl` is just cooler :)

https://github.com/randovania/open-samus-returns-rando/assets/38679103/e36ea666-9366-42bf-806f-aac40555076e

