### PR TITLE
Add custom chozo seals

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/src/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -76,7 +76,7 @@ function s100_area10.InitFromBlackboard()
   Scenario.WriteToBlackboard("firstTimeMetroidHatchlingIntroPlayed", "b", true)
   Game.DisableEntity("LE_Baby_Hatchling")
   Game.DisableTrigger("TG_MetroidRadar")
-  Game.GetEntity("LE_RandoDNA").USABLE:Activate(false)
+  Game.GetEntity("LE_RandoDNA_002").USABLE:Activate(false)
   if Game.GetEntity("LE_ValveQueen") ~= nil then
     if Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") ~= nil and s100_area10.iNumMetroids == Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") then
       Game.GetEntity("LE_ValveQueen").MODELUPDATER:SetMeshVisible("Valve", false)
@@ -273,7 +273,7 @@ function s100_area10.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_
     Game.SetSceneGroupEnabledByName("sg_egg01", false)
     Game.SetSceneGroupEnabledByName("sg_egg02", true)
     Game.EnableEntity("LE_Baby_Hatchling")
-    Game.GetEntity("LE_RandoDNA").USABLE:Activate(true)
+    Game.GetEntity("LE_RandoDNA_002").USABLE:Activate(true)
   end
   if _ARG_2_ == "collision_camera_020" then
     s100_area10.fSafeFarPlaneFactor = Game.GetSafeFarPlaneFactor()

--- a/src/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/src/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -76,6 +76,7 @@ function s100_area10.InitFromBlackboard()
   Scenario.WriteToBlackboard("firstTimeMetroidHatchlingIntroPlayed", "b", true)
   Game.DisableEntity("LE_Baby_Hatchling")
   Game.DisableTrigger("TG_MetroidRadar")
+  Game.GetEntity("LE_RandoDNA").USABLE:Activate(false)
   if Game.GetEntity("LE_ValveQueen") ~= nil then
     if Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") ~= nil and s100_area10.iNumMetroids == Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") then
       Game.GetEntity("LE_ValveQueen").MODELUPDATER:SetMeshVisible("Valve", false)
@@ -272,6 +273,7 @@ function s100_area10.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_
     Game.SetSceneGroupEnabledByName("sg_egg01", false)
     Game.SetSceneGroupEnabledByName("sg_egg02", true)
     Game.EnableEntity("LE_Baby_Hatchling")
+    Game.GetEntity("LE_RandoDNA").USABLE:Activate(true)
   end
   if _ARG_2_ == "collision_camera_020" then
     s100_area10.fSafeFarPlaneFactor = Game.GetSafeFarPlaneFactor()

--- a/src/open_samus_returns_rando/patcher_editor.py
+++ b/src/open_samus_returns_rando/patcher_editor.py
@@ -73,3 +73,6 @@ class PatcherEditor(FileTreeEditor):
 
         scenario.raw.actors[layer].pop(actor_name)
         scenario.remove_actor_from_all_groups(actor_name)
+
+    def get_asset_names_in_folder(self, folder: str) -> typing.Iterator[str]:
+        yield from (name for name in self._name_for_asset_id.values() if name.startswith(folder))

--- a/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
@@ -95,14 +95,14 @@ def add_chozo_seals(editor: PatcherEditor, new_seal: NewChozoSeal):
     scenario_name = new_seal.scenario
     scenario_file = editor.get_scenario(scenario_name)
 
-    editor.copy_actor(new_seal.scenario, new_seal.ap_coordinates, template_ap, new_seal.ap_name, 16)
-    editor.copy_actor(new_seal.scenario, new_seal.platform_coordinates, template_platform, new_seal.platform_name, 10)
+    editor.copy_actor(scenario_name, new_seal.ap_coordinates, template_ap, new_seal.ap_name, 16)
+    editor.copy_actor(scenario_name, new_seal.platform_coordinates, template_platform, new_seal.platform_name, 10)
     scenario_file.raw.actors[10][new_seal.platform_name]["components"][0]["arguments"][4]["value"] = new_seal.ap_name
 
-    if new_seal.scenario == "s110_surfaceb":
+    if scenario_name == "s110_surfaceb":
         scenario_map = editor.get_file("gui/minimaps/c10_samus/s000_surface.bmsmsd", Bmsmsd)
     else:
-        scenario_map = editor.get_file(f"gui/minimaps/c10_samus/{new_seal.scenario}.bmsmsd", Bmsmsd)
+        scenario_map = editor.get_file(f"gui/minimaps/c10_samus/{scenario_name}.bmsmsd", Bmsmsd)
 
     scenario_map.raw["tiles"][new_seal.tile_index]["icons"] = ListContainer([CHOZO_SEAL_ICON])
 
@@ -111,9 +111,9 @@ def add_chozo_seals(editor: PatcherEditor, new_seal: NewChozoSeal):
         scenario_file.add_actor_to_entity_groups(entity_group, new_seal.platform_name, True)
 
     # Dependencies
-    editor.ensure_present_in_scenario(new_seal.scenario, "maps/textures/dnaemptyfx_d.bctex")
+    editor.ensure_present_in_scenario(scenario_name, "maps/textures/dnaemptyfx_d.bctex")
     for asset in editor.get_asset_names_in_folder("actors/props/systemmechdna"):
-        editor.ensure_present_in_scenario(new_seal.scenario, asset)
+        editor.ensure_present_in_scenario(scenario_name, asset)
 
 
 def patch_chozo_seals(editor: PatcherEditor):

--- a/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
@@ -45,270 +45,122 @@ def patch_dna_check(editor: PatcherEditor):
     editor.replace_asset(file_name, systemmechdna)
 
 
-def _get_accesspoint(editor: PatcherEditor):
-    accesspoint = {
-        "scenario": "s000_surface",
-        "layer": "16",
-        "actor": "LE_ChozoUnlockAreaDNA",
+def add_chozo_seals(editor: PatcherEditor):
+    SCENARIOS = {
+        "s033_area3b": [[-3800.0, -16800.0, 0.0]],
+        "s050_area5": [[12250.0, 6700.0, 0.0]],
+        "s065_area6b": [[-300.0, 5700.0, 0.0]],
+        "s100_area10": [[-1000.0, -5100.0, 0.0], [-4100.0, 11200.0, 0.0]],
+        "s110_surfaceb": [[-28150.0, 300.0, 0.0]],
     }
-    ap = editor.resolve_actor_reference(accesspoint)
-    return ap
+    for scenario, actor_coordinates in SCENARIOS.items():
+        template_ap = editor.get_scenario("s000_surface").raw.actors[16]["LE_ChozoUnlockAreaDNA"]
+        template_platform = editor.get_scenario("s000_surface").raw.actors[10]["LE_Platform_ChozoUnlockAreaDNA"]
 
+        scenario_name = scenario
+        scenario_file = editor.get_scenario(scenario_name)
 
-def _get_accesspoint_platform(editor: PatcherEditor):
-    accesspoint_platform = {
-        "scenario": "s000_surface",
-        "layer": "10",
-        "actor": "LE_Platform_ChozoUnlockAreaDNA",
-    }
-    ap_platform = editor.resolve_actor_reference(accesspoint_platform)
-    return ap_platform
+        if scenario == "s110_surfaceb":
+            scenario_map = editor.get_file("gui/minimaps/c10_samus/s000_surface.bmsmsd", Bmsmsd)
+        else:
+            scenario_map = editor.get_file(f"gui/minimaps/c10_samus/{scenario}.bmsmsd", Bmsmsd)
 
-
-def add_area3b_seal(editor: PatcherEditor):
-    CHOZO_SEAL_ICON = Container({
-        "actor_name": "LE_RandoDNA",
-        "clear_condition": "",
-        "icon": "systemmechdna",
-        "icon_priority": 4,
-        "coordinates": ListContainer([
-            -3800.0, -16800.0, 0.0
-        ]),
-    })
-
-    scenario = "s033_area3b"
-    area3b = editor.get_scenario(scenario)
-    ap = "LE_RandoDNA"
-    ap_platform = "LE_Platform_RandoDNA"
-
-    accesspoint = _get_accesspoint(editor)
-    accesspoint_platform = _get_accesspoint_platform(editor)
-
-    editor.copy_actor(
-        scenario, (-3800.0, -16800.0, 0.0), accesspoint, ap, 16,
-    )
-
-    editor.copy_actor(
-        scenario, (-3800.0, -16800.0, 0.0), accesspoint_platform, ap_platform, 10,
-    )
-
-    area3b.add_actor_to_entity_groups("collision_camera_033", ap)
-    area3b.add_actor_to_entity_groups("PostGamma_004", ap)
-    area3b.add_actor_to_entity_groups("collision_camera_033", ap_platform)
-    area3b.add_actor_to_entity_groups("PostGamma_004", ap_platform)
-
-    area3b.raw.actors[10][ap_platform]["components"][0]["arguments"][4]["value"] = ap
-
-    area3b_map = editor.get_file("gui/minimaps/c10_samus/s033_area3b.bmsmsd", Bmsmsd)
-    area3b_map.raw["tiles"][22]["icons"] = ListContainer([CHOZO_SEAL_ICON])
-
-
-def add_area5_seal(editor: PatcherEditor):
-    CHOZO_SEAL_ICON = Container({
-        "actor_name": "LE_RandoDNA",
-        "clear_condition": "",
-        "icon": "systemmechdna",
-        "icon_priority": 4,
-        "coordinates": ListContainer([
-            12250.0, 6700.0, 0.0
-        ]),
-    })
-
-    scenario = "s050_area5"
-    area5 = editor.get_scenario(scenario)
-    ap = "LE_RandoDNA"
-    ap_platform = "LE_Platform_RandoDNA"
-
-    accesspoint = _get_accesspoint(editor)
-    accesspoint_platform = _get_accesspoint_platform(editor)
-
-    editor.copy_actor(
-        scenario, (12250.0, 6700.0, 20.0), accesspoint, ap, 16,
-    )
-
-    editor.copy_actor(
-        scenario, (12250.0, 6700.0, 0.0), accesspoint_platform, ap_platform, 10,
-    )
-
-    area5.add_actor_to_entity_groups("collision_camera_017", ap, True)
-    area5.add_actor_to_entity_groups("017_PostGamma_002", ap, True)
-    area5.add_actor_to_entity_groups("PostGamma_002", ap, True)
-    area5.add_actor_to_entity_groups("collision_camera_017", ap_platform, True)
-    area5.add_actor_to_entity_groups("017_PostGamma_002", ap_platform, True)
-    area5.add_actor_to_entity_groups("PostGamma_002", ap_platform, True)
-
-    area5.raw.actors[10][ap_platform]["components"][0]["arguments"][4]["value"] = ap
-
-    area5_map = editor.get_file("gui/minimaps/c10_samus/s050_area5.bmsmsd", Bmsmsd)
-    area5_map.raw["tiles"][238]["icons"] = ListContainer([CHOZO_SEAL_ICON])
-
-
-def add_area6b_seal(editor: PatcherEditor):
-    CHOZO_SEAL_ICON = Container({
-        "actor_name": "LE_RandoDNA",
-        "clear_condition": "",
-        "icon": "systemmechdna",
-        "icon_priority": 4,
-        "coordinates": ListContainer([
-            500.0, 5700.0, 0.0
-        ]),
-    })
-
-    scenario = "s065_area6b"
-    area6b = editor.get_scenario(scenario)
-    ap = "LE_RandoDNA"
-    ap_platform = "LE_Platform_RandoDNA"
-
-    accesspoint = _get_accesspoint(editor)
-    accesspoint_platform = _get_accesspoint_platform(editor)
-
-    editor.copy_actor(
-        scenario, (500.0, 5700.0, 25.0), accesspoint, ap, 16,
-    )
-
-    editor.copy_actor(
-        scenario, (500.0, 5700.0, 0.0), accesspoint_platform, ap_platform, 10,
-    )
-
-    area6b.add_actor_to_entity_groups("collision_camera_002", ap, True)
-    area6b.add_actor_to_entity_groups("collision_camera_002", ap_platform, True)
-
-    area6b.raw.actors[10][ap_platform]["components"][0]["arguments"][4]["value"] = ap
-
-    area6b_map = editor.get_file("gui/minimaps/c10_samus/s065_area6b.bmsmsd", Bmsmsd)
-    area6b_map.raw["tiles"][217]["icons"] = ListContainer([CHOZO_SEAL_ICON])
-
-
-def add_area10_1_seal(editor: PatcherEditor):
-    CHOZO_SEAL_ICON = Container({
-        "actor_name": "LE_RandoDNA_001",
-        "clear_condition": "",
-        "icon": "systemmechdna",
-        "icon_priority": 4,
-        "coordinates": ListContainer([
-            -1000.0, -5125.0, 0.0
-        ]),
-    })
-
-    scenario = "s100_area10"
-    area10 = editor.get_scenario(scenario)
-    ap = "LE_RandoDNA_001"
-    ap_platform = "LE_Platform_RandoDNA_001"
-
-    accesspoint = _get_accesspoint(editor)
-    accesspoint_platform = _get_accesspoint_platform(editor)
-
-    editor.copy_actor(
-        scenario, (-1000.0, -5100.0, 0.0), accesspoint, ap, 16,
-    )
-
-    editor.copy_actor(
-        scenario, (-1000.0, -5100.0, 0.0), accesspoint_platform, ap_platform, 10,
-    )
-
-    area10.add_actor_to_entity_groups("collision_camera_010", ap, True)
-    area10.add_actor_to_entity_groups("collision_camera_010", ap_platform, True)
-
-    area10.raw.actors[10][ap_platform]["components"][0]["arguments"][4]["value"] = ap
-
-    area10_map = editor.get_file("gui/minimaps/c10_samus/s100_area10.bmsmsd", Bmsmsd)
-    area10_map.raw["tiles"][94]["icons"] = ListContainer([CHOZO_SEAL_ICON])
-
-
-def add_area10_2_seal(editor: PatcherEditor):
-    CHOZO_SEAL_ICON = Container({
-        "actor_name": "LE_RandoDNA_002",
-        "clear_condition": "",
-        "icon": "systemmechdna",
-        "icon_priority": 4,
-        "coordinates": ListContainer([
-            -4100.0, 11200.0, 0.0
-        ]),
-    })
-
-    scenario = "s100_area10"
-    area10 = editor.get_scenario(scenario)
-    ap = "LE_RandoDNA_002"
-    ap_platform = "LE_Platform_RandoDNA_002"
-
-    accesspoint = _get_accesspoint(editor)
-    accesspoint_platform = _get_accesspoint_platform(editor)
-
-    editor.copy_actor(
-        scenario, (-4100.0, 11200.0, 10.0), accesspoint, ap, 16,
-    )
-
-    editor.copy_actor(
-        scenario, (-4100.0, 11200.0, 0.0), accesspoint_platform, ap_platform, 10,
-    )
-
-    area10.add_actor_to_entity_groups("collision_camera_022", ap)
-    area10.add_actor_to_entity_groups("collision_camera_024", ap)
-    area10.add_actor_to_entity_groups("collision_camera_022", ap_platform)
-    area10.add_actor_to_entity_groups("collision_camera_024", ap_platform)
-
-    area10.raw.actors[10][ap_platform]["components"][0]["arguments"][4]["value"] = ap
-
-    area10_map = editor.get_file("gui/minimaps/c10_samus/s100_area10.bmsmsd", Bmsmsd)
-    area10_map.raw["tiles"][253]["icons"] = ListContainer([CHOZO_SEAL_ICON])
-
-
-def add_surfaceb_seal(editor: PatcherEditor):
-    CHOZO_SEAL_ICON = Container({
-        "actor_name": "LE_RandoDNA",
-        "clear_condition": "",
-        "icon": "systemmechdna",
-        "icon_priority": 4,
-        "coordinates": ListContainer([
-            -28150.0, 300.0, 0.0
-        ]),
-    })
-
-    scenario = "s110_surfaceb"
-    surfaceb = editor.get_scenario(scenario)
-    ap = "LE_RandoDNA"
-    ap_platform = "LE_Platform_RandoDNA"
-
-    accesspoint = _get_accesspoint(editor)
-    accesspoint_platform = _get_accesspoint_platform(editor)
-
-    editor.copy_actor(
-        scenario, (-28150.0, 300.0, 0.0), accesspoint, ap, 16,
-    )
-
-    editor.copy_actor(
-        scenario, (-28150.0, 300.0, 0.0), accesspoint_platform, ap_platform, 10,
-    )
-
-    surfaceb.add_actor_to_entity_groups("collision_camera_017", ap)
-    surfaceb.add_actor_to_entity_groups("collision_camera_017", ap_platform)
-
-    surfaceb.raw.actors[10][ap_platform]["components"][0]["arguments"][4]["value"] = ap
-
-    surface_map = editor.get_file("gui/minimaps/c10_samus/s000_surface.bmsmsd", Bmsmsd)
-    surface_map.raw["tiles"][145]["icons"] = ListContainer([CHOZO_SEAL_ICON])
-
-
-def ensure_dependencies(editor: PatcherEditor) -> None:
-    SCENARIOS = [
-        "s033_area3b",
-        "s050_area5",
-        "s065_area6b",
-        "s100_area10",
-        "s110_surfaceb",
-    ]
-    for scenario in SCENARIOS:
+        # Dependencies
         editor.ensure_present_in_scenario(scenario, "maps/textures/dnaemptyfx_d.bctex")
         for asset in editor.get_asset_names_in_folder("actors/props/systemmechdna"):
             editor.ensure_present_in_scenario(scenario, asset)
 
+        if scenario != "s100_area10":
+            new_ap = "LE_RandoDNA"
+            new_platform = "LE_Platform_RandoDNA"
+            for position in actor_coordinates:
+                coordinates = position
+                CHOZO_SEAL_ICON = Container({
+                    "actor_name": "LE_RandoDNA",
+                    "clear_condition": "",
+                    "icon": "systemmechdna",
+                    "icon_priority": 4,
+                    "coordinates": ListContainer(coordinates),
+                })
+                editor.copy_actor(scenario, coordinates, template_platform, new_platform, 10)
+                # Scenarios that need to adjust the position of the Chozo Seal are listed first
+                if scenario == "s050_area5":
+                    editor.copy_actor(scenario, (12250.0, 6700.0, 20.0), template_ap, new_ap, 16)
+                elif scenario == "s065_area6b":
+                    editor.copy_actor(scenario, (-300.0, 5700.0, 25.0), template_ap, new_ap, 16)
+                else:
+                    editor.copy_actor(scenario, coordinates, template_ap, new_ap, 16)
+
+                scenario_file.raw.actors[10][new_platform]["components"][0]["arguments"][4]["value"] = new_ap
+
+                if scenario == "s033_area3b":
+                    scenario_map.raw["tiles"][22]["icons"] = ListContainer([CHOZO_SEAL_ICON])
+                    scenario_file.add_actor_to_entity_groups("collision_camera_033", new_ap)
+                    scenario_file.add_actor_to_entity_groups("PostGamma_004", new_ap)
+                    scenario_file.add_actor_to_entity_groups("collision_camera_033", new_platform)
+                    scenario_file.add_actor_to_entity_groups("PostGamma_004", new_platform)
+                if scenario == "s050_area5":
+                    scenario_map.raw["tiles"][238]["icons"] = ListContainer([CHOZO_SEAL_ICON])
+                    scenario_file.add_actor_to_entity_groups("collision_camera_017", new_ap, True)
+                    scenario_file.add_actor_to_entity_groups("017_PostGamma_002", new_ap, True)
+                    scenario_file.add_actor_to_entity_groups("PostGamma_002", new_ap, True)
+                    scenario_file.add_actor_to_entity_groups("collision_camera_017", new_platform, True)
+                    scenario_file.add_actor_to_entity_groups("017_PostGamma_002", new_platform, True)
+                    scenario_file.add_actor_to_entity_groups("PostGamma_002", new_platform, True)
+                if scenario == "s065_area6b":
+                    scenario_map.raw["tiles"][216]["icons"] = ListContainer([CHOZO_SEAL_ICON])
+                    scenario_file.add_actor_to_entity_groups("collision_camera_002", new_ap, True)
+                    scenario_file.add_actor_to_entity_groups("collision_camera_002", new_platform, True)
+                if scenario == "s110_surfaceb":
+                    scenario_map.raw["tiles"][145]["icons"] = ListContainer([CHOZO_SEAL_ICON])
+                    scenario_file.add_actor_to_entity_groups("collision_camera_017", new_ap)
+                    scenario_file.add_actor_to_entity_groups("collision_camera_017", new_platform)
+        else:
+            # Area 8 is separate due to having two new seals
+            new_ap_001 = "LE_RandoDNA_001"
+            new_platform_001 = "LE_Platform_RandoDNA_001"
+            new_ap_002 = "LE_RandoDNA_002"
+            new_platform_002 = "LE_Platform_RandoDNA_002"
+
+            coordinates_001 = actor_coordinates[0]
+            coordinates_002 = actor_coordinates[1]
+
+            editor.copy_actor(scenario, (-1000.0, -5125.0, 0.0), template_ap, new_ap_001, 16)
+            editor.copy_actor(scenario, coordinates_001, template_platform, new_platform_001, 10)
+            editor.copy_actor(scenario, coordinates_002, template_ap, new_ap_002, 16)
+            editor.copy_actor(scenario, coordinates_002, template_platform, new_platform_002, 10)
+
+            scenario_file.raw.actors[10][new_platform_001]["components"][0]["arguments"][4]["value"] = new_ap_001
+            scenario_file.raw.actors[10][new_platform_002]["components"][0]["arguments"][4]["value"] = new_ap_002
+
+            scenario_file.add_actor_to_entity_groups("collision_camera_010", new_ap_001, True)
+            scenario_file.add_actor_to_entity_groups("collision_camera_010", new_platform_001, True)
+            scenario_file.add_actor_to_entity_groups("collision_camera_022", new_ap_002)
+            scenario_file.add_actor_to_entity_groups("collision_camera_024", new_ap_002)
+            scenario_file.add_actor_to_entity_groups("collision_camera_022", new_platform_002)
+            scenario_file.add_actor_to_entity_groups("collision_camera_024", new_platform_002)
+
+            scenario_map.raw["tiles"][94]["icons"] = ListContainer([
+                Container({
+                    "actor_name": "LE_RandoDNA_001",
+                    "clear_condition": "",
+                    "icon": "systemmechdna",
+                    "icon_priority": 4,
+                    "coordinates": ListContainer(coordinates_001),
+                })
+            ])
+
+            scenario_map.raw["tiles"][253]["icons"] = ListContainer([
+                Container({
+                    "actor_name": "LE_RandoDNA_002",
+                    "clear_condition": "",
+                    "icon": "systemmechdna",
+                    "icon_priority": 4,
+                    "coordinates": ListContainer(coordinates_002),
+                })
+            ])
+
 
 def patch_chozo_seals(editor: PatcherEditor):
     patch_dna_check(editor)
-    ensure_dependencies(editor)
-    add_area3b_seal(editor)
-    add_area5_seal(editor)
-    add_area6b_seal(editor)
-    add_area10_1_seal(editor)
-    add_area10_2_seal(editor)
-    add_surfaceb_seal(editor)
+    add_chozo_seals(editor)

--- a/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
@@ -49,8 +49,8 @@ def patch_dna_check(editor: PatcherEditor):
 
 class NewChozoSeal(typing.NamedTuple):
     scenario: str
-    ap_coordinates: tuple[(float, float, float)]
-    platform_coordinates: tuple[(float, float, float)]
+    ap_coordinates: list[float]
+    platform_coordinates: list[float]
     tile_index: int
     entity_groups: list[str]
     ap_name: str = "LE_RandoDNA"

--- a/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
@@ -1,5 +1,5 @@
 from construct import Container, ListContainer
-from mercury_engine_data_structures.formats import Bmsad
+from mercury_engine_data_structures.formats import Bmsad, Bmsmsd
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 SCRIPT_COMPONENT = Container({
@@ -45,5 +45,270 @@ def patch_dna_check(editor: PatcherEditor):
     editor.replace_asset(file_name, systemmechdna)
 
 
+def _get_accesspoint(editor: PatcherEditor):
+    accesspoint = {
+        "scenario": "s000_surface",
+        "layer": "16",
+        "actor": "LE_ChozoUnlockAreaDNA",
+    }
+    ap = editor.resolve_actor_reference(accesspoint)
+    return ap
+
+
+def _get_accesspoint_platform(editor: PatcherEditor):
+    accesspoint_platform = {
+        "scenario": "s000_surface",
+        "layer": "10",
+        "actor": "LE_Platform_ChozoUnlockAreaDNA",
+    }
+    ap_platform = editor.resolve_actor_reference(accesspoint_platform)
+    return ap_platform
+
+
+def add_area3b_seal(editor: PatcherEditor):
+    CHOZO_SEAL_ICON = Container({
+        "actor_name": "LE_RandoDNA",
+        "clear_condition": "",
+        "icon": "systemmechdna",
+        "icon_priority": 4,
+        "coordinates": ListContainer([
+            -3800.0, -16800.0, 0.0
+        ]),
+    })
+
+    scenario = "s033_area3b"
+    area3b = editor.get_scenario(scenario)
+    ap = "LE_RandoDNA"
+    ap_platform = "LE_Platform_RandoDNA"
+
+    accesspoint = _get_accesspoint(editor)
+    accesspoint_platform = _get_accesspoint_platform(editor)
+
+    editor.copy_actor(
+        scenario, (-3800.0, -16800.0, 0.0), accesspoint, ap, 16,
+    )
+
+    editor.copy_actor(
+        scenario, (-3800.0, -16800.0, 0.0), accesspoint_platform, ap_platform, 10,
+    )
+
+    area3b.add_actor_to_entity_groups("collision_camera_033", ap)
+    area3b.add_actor_to_entity_groups("PostGamma_004", ap)
+    area3b.add_actor_to_entity_groups("collision_camera_033", ap_platform)
+    area3b.add_actor_to_entity_groups("PostGamma_004", ap_platform)
+
+    area3b.raw.actors[10][ap_platform]["components"][0]["arguments"][4]["value"] = ap
+
+    area3b_map = editor.get_file("gui/minimaps/c10_samus/s033_area3b.bmsmsd", Bmsmsd)
+    area3b_map.raw["tiles"][22]["icons"] = ListContainer([CHOZO_SEAL_ICON])
+
+
+def add_area5_seal(editor: PatcherEditor):
+    CHOZO_SEAL_ICON = Container({
+        "actor_name": "LE_RandoDNA",
+        "clear_condition": "",
+        "icon": "systemmechdna",
+        "icon_priority": 4,
+        "coordinates": ListContainer([
+            12250.0, 6700.0, 0.0
+        ]),
+    })
+
+    scenario = "s050_area5"
+    area5 = editor.get_scenario(scenario)
+    ap = "LE_RandoDNA"
+    ap_platform = "LE_Platform_RandoDNA"
+
+    accesspoint = _get_accesspoint(editor)
+    accesspoint_platform = _get_accesspoint_platform(editor)
+
+    editor.copy_actor(
+        scenario, (12250.0, 6700.0, 20.0), accesspoint, ap, 16,
+    )
+
+    editor.copy_actor(
+        scenario, (12250.0, 6700.0, 0.0), accesspoint_platform, ap_platform, 10,
+    )
+
+    area5.add_actor_to_entity_groups("collision_camera_017", ap, True)
+    area5.add_actor_to_entity_groups("017_PostGamma_002", ap, True)
+    area5.add_actor_to_entity_groups("PostGamma_002", ap, True)
+    area5.add_actor_to_entity_groups("collision_camera_017", ap_platform, True)
+    area5.add_actor_to_entity_groups("017_PostGamma_002", ap_platform, True)
+    area5.add_actor_to_entity_groups("PostGamma_002", ap_platform, True)
+
+    area5.raw.actors[10][ap_platform]["components"][0]["arguments"][4]["value"] = ap
+
+    area5_map = editor.get_file("gui/minimaps/c10_samus/s050_area5.bmsmsd", Bmsmsd)
+    area5_map.raw["tiles"][238]["icons"] = ListContainer([CHOZO_SEAL_ICON])
+
+
+def add_area6b_seal(editor: PatcherEditor):
+    CHOZO_SEAL_ICON = Container({
+        "actor_name": "LE_RandoDNA",
+        "clear_condition": "",
+        "icon": "systemmechdna",
+        "icon_priority": 4,
+        "coordinates": ListContainer([
+            500.0, 5700.0, 0.0
+        ]),
+    })
+
+    scenario = "s065_area6b"
+    area6b = editor.get_scenario(scenario)
+    ap = "LE_RandoDNA"
+    ap_platform = "LE_Platform_RandoDNA"
+
+    accesspoint = _get_accesspoint(editor)
+    accesspoint_platform = _get_accesspoint_platform(editor)
+
+    editor.copy_actor(
+        scenario, (500.0, 5700.0, 25.0), accesspoint, ap, 16,
+    )
+
+    editor.copy_actor(
+        scenario, (500.0, 5700.0, 0.0), accesspoint_platform, ap_platform, 10,
+    )
+
+    area6b.add_actor_to_entity_groups("collision_camera_002", ap, True)
+    area6b.add_actor_to_entity_groups("collision_camera_002", ap_platform, True)
+
+    area6b.raw.actors[10][ap_platform]["components"][0]["arguments"][4]["value"] = ap
+
+    area6b_map = editor.get_file("gui/minimaps/c10_samus/s065_area6b.bmsmsd", Bmsmsd)
+    area6b_map.raw["tiles"][217]["icons"] = ListContainer([CHOZO_SEAL_ICON])
+
+
+def add_area10_1_seal(editor: PatcherEditor):
+    CHOZO_SEAL_ICON = Container({
+        "actor_name": "LE_RandoDNA_001",
+        "clear_condition": "",
+        "icon": "systemmechdna",
+        "icon_priority": 4,
+        "coordinates": ListContainer([
+            -1000.0, -5125.0, 0.0
+        ]),
+    })
+
+    scenario = "s100_area10"
+    area10 = editor.get_scenario(scenario)
+    ap = "LE_RandoDNA_001"
+    ap_platform = "LE_Platform_RandoDNA_001"
+
+    accesspoint = _get_accesspoint(editor)
+    accesspoint_platform = _get_accesspoint_platform(editor)
+
+    editor.copy_actor(
+        scenario, (-1000.0, -5100.0, 0.0), accesspoint, ap, 16,
+    )
+
+    editor.copy_actor(
+        scenario, (-1000.0, -5100.0, 0.0), accesspoint_platform, ap_platform, 10,
+    )
+
+    area10.add_actor_to_entity_groups("collision_camera_010", ap, True)
+    area10.add_actor_to_entity_groups("collision_camera_010", ap_platform, True)
+
+    area10.raw.actors[10][ap_platform]["components"][0]["arguments"][4]["value"] = ap
+
+    area10_map = editor.get_file("gui/minimaps/c10_samus/s100_area10.bmsmsd", Bmsmsd)
+    area10_map.raw["tiles"][94]["icons"] = ListContainer([CHOZO_SEAL_ICON])
+
+
+def add_area10_2_seal(editor: PatcherEditor):
+    CHOZO_SEAL_ICON = Container({
+        "actor_name": "LE_RandoDNA_002",
+        "clear_condition": "",
+        "icon": "systemmechdna",
+        "icon_priority": 4,
+        "coordinates": ListContainer([
+            -4100.0, 11200.0, 0.0
+        ]),
+    })
+
+    scenario = "s100_area10"
+    area10 = editor.get_scenario(scenario)
+    ap = "LE_RandoDNA_002"
+    ap_platform = "LE_Platform_RandoDNA_002"
+
+    accesspoint = _get_accesspoint(editor)
+    accesspoint_platform = _get_accesspoint_platform(editor)
+
+    editor.copy_actor(
+        scenario, (-4100.0, 11200.0, 10.0), accesspoint, ap, 16,
+    )
+
+    editor.copy_actor(
+        scenario, (-4100.0, 11200.0, 0.0), accesspoint_platform, ap_platform, 10,
+    )
+
+    area10.add_actor_to_entity_groups("collision_camera_022", ap)
+    area10.add_actor_to_entity_groups("collision_camera_024", ap)
+    area10.add_actor_to_entity_groups("collision_camera_022", ap_platform)
+    area10.add_actor_to_entity_groups("collision_camera_024", ap_platform)
+
+    area10.raw.actors[10][ap_platform]["components"][0]["arguments"][4]["value"] = ap
+
+    area10_map = editor.get_file("gui/minimaps/c10_samus/s100_area10.bmsmsd", Bmsmsd)
+    area10_map.raw["tiles"][253]["icons"] = ListContainer([CHOZO_SEAL_ICON])
+
+
+def add_surfaceb_seal(editor: PatcherEditor):
+    CHOZO_SEAL_ICON = Container({
+        "actor_name": "LE_RandoDNA",
+        "clear_condition": "",
+        "icon": "systemmechdna",
+        "icon_priority": 4,
+        "coordinates": ListContainer([
+            -28150.0, 300.0, 0.0
+        ]),
+    })
+
+    scenario = "s110_surfaceb"
+    surfaceb = editor.get_scenario(scenario)
+    ap = "LE_RandoDNA"
+    ap_platform = "LE_Platform_RandoDNA"
+
+    accesspoint = _get_accesspoint(editor)
+    accesspoint_platform = _get_accesspoint_platform(editor)
+
+    editor.copy_actor(
+        scenario, (-28150.0, 300.0, 0.0), accesspoint, ap, 16,
+    )
+
+    editor.copy_actor(
+        scenario, (-28150.0, 300.0, 0.0), accesspoint_platform, ap_platform, 10,
+    )
+
+    surfaceb.add_actor_to_entity_groups("collision_camera_017", ap)
+    surfaceb.add_actor_to_entity_groups("collision_camera_017", ap_platform)
+
+    surfaceb.raw.actors[10][ap_platform]["components"][0]["arguments"][4]["value"] = ap
+
+    surface_map = editor.get_file("gui/minimaps/c10_samus/s000_surface.bmsmsd", Bmsmsd)
+    surface_map.raw["tiles"][145]["icons"] = ListContainer([CHOZO_SEAL_ICON])
+
+
+def ensure_dependencies(editor: PatcherEditor) -> None:
+    SCENARIOS = [
+        "s033_area3b",
+        "s050_area5",
+        "s065_area6b",
+        "s100_area10",
+        "s110_surfaceb",
+    ]
+    for scenario in SCENARIOS:
+        editor.ensure_present_in_scenario(scenario, "maps/textures/dnaemptyfx_d.bctex")
+        for asset in editor.get_asset_names_in_folder("actors/props/systemmechdna"):
+            editor.ensure_present_in_scenario(scenario, asset)
+
+
 def patch_chozo_seals(editor: PatcherEditor):
     patch_dna_check(editor)
+    ensure_dependencies(editor)
+    add_area3b_seal(editor)
+    add_area5_seal(editor)
+    add_area6b_seal(editor)
+    add_area10_1_seal(editor)
+    add_area10_2_seal(editor)
+    add_surfaceb_seal(editor)


### PR DESCRIPTION
Adds new Chozo Seals to areas scenarios which do not have them. These new seals will be strictly used for DNA hints. Seals have been added to the following scenarios:

area3b - Lowest Gamma+ Arena

![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/b8a7553d-c8a7-4101-97d1-f2de7ec106a8)

area5 - Gamma Arena Lower CC

![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/2a8502de-722f-4403-99c8-a3c19c742782)

area6b - Top of Tower

![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/6d2fdf73-169a-471d-8f04-26ef99e0bb69)
 
area10 - Middle Hallway before the big room

![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/da6da03b-ec7f-43f4-81ba-d51ac68ae60e)

area10 - After the Queen (deactivated until the Queen is defeated)

![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/9ef2ffd8-912e-4575-ba66-1463b09a557b)

surfaceb - Before the Teleporter

![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/8f323932-bfb1-44ac-947d-c16873cff444)

Unsure how many of these I should add, or if I should add more. I think adding one more earlier on that doesn't require many items could be a good thing. Unsure about adding one in a6/a7 though.