### PR TITLE
Door and Map updates

### DIFF
--- a/src/open_samus_returns_rando/specific_patches/door_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/door_patches.py
@@ -175,7 +175,9 @@ def _patch_one_way_doors(editor: PatcherEditor):
         "s030_area3": ["Door005", "Door006"],
         # Chozo Seal Spazer Door
         "s040_area4": ["Door001"],
-        # Plasma Room Plasma and Missile doors, Gravity Room Missile Door
+        # Super Missile Room Super Door
+        "s050_area5": ["Door005"],
+        # Plasma Room Plasma and Missile Doors, Gravity Room Missile Door
         "s067_area6c": ["Door005", "Door006", "Door009"]
     }
 

--- a/src/open_samus_returns_rando/specific_patches/door_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/door_patches.py
@@ -125,7 +125,7 @@ def _patch_beam_covers(editor: PatcherEditor):
             actor = scenario.raw.actors[9][cover_name]
             new_actor_name = f"{cover_name}_o"
             new_actor = editor.copy_actor(
-                scenario_name, (actor["position"][0], actor["position"][1],  actor["position"][2]),
+                scenario_name, (actor["position"][0], actor["position"][1], actor["position"][2]),
                 actor, new_actor_name, 9
             )
             new_actor["rotation"][0] = 0
@@ -145,7 +145,6 @@ def _patch_beam_covers(editor: PatcherEditor):
                     if group_name in list(scenario.all_actor_group_names_for_actor(cover_name))]
             for group in entity_groups:
                 scenario.insert_into_entity_group(group, new_actor_name)
-
 
 
 def _patch_charge_doors(editor: PatcherEditor):

--- a/src/open_samus_returns_rando/specific_patches/map_icons.py
+++ b/src/open_samus_returns_rando/specific_patches/map_icons.py
@@ -12,6 +12,7 @@ def patch_tiles(editor: PatcherEditor):
         "s028_area2c": ["Door001", "Door007"],
         "s030_area3": ["Door002", "Door005", "Door006", "Door008"],
         "s040_area4": ["Door001", "Door006", "Door014"],
+        "s050_area5": ["Door005"],
         "s060_area6": ["Door001"],
         "s067_area6c": ["Door005", "Door006", "Door009"],
         "s090_area9": ["Door012"],

--- a/src/open_samus_returns_rando/specific_patches/map_icons.py
+++ b/src/open_samus_returns_rando/specific_patches/map_icons.py
@@ -43,7 +43,8 @@ def patch_tiles(editor: PatcherEditor):
                     for door in doors:
                         if door in door_tile["actor_name"]:
                             door_tile["clear_condition"] = ""
-                            if "left" in door_tile["icon"]:
-                                door_tile["icon"] = "doorpowerleft"
-                            else:
-                                door_tile["icon"] = "doorpowerright"
+                            if "closed" in door_tile["icon"]:
+                                if "left" in door_tile["icon"]:
+                                    door_tile["icon"] = "doorpowerleft"
+                                else:
+                                    door_tile["icon"] = "doorpowerright"


### PR DESCRIPTION
- Make the Super door connecting to Supers Room be double sided
- Certain shield tiles were incorrectly being changed to Power while their shields were active. Now all shields should be properly shown on the map 