### PR TITLE
Fix Missile Reserve Tanks not refilling Missiles

### DIFF
--- a/src/open_samus_returns_rando/files/pickups/randomizermissilelauncher.lua
+++ b/src/open_samus_returns_rando/files/pickups/randomizermissilelauncher.lua
@@ -10,11 +10,10 @@ function RandomizerMissileLauncher.OnPickedUp(progression)
             if inner.item_id == "ITEM_MISSILE_TANKS" then
                 inner.item_id = "ITEM_WEAPON_MISSILE_MAX"
                 inner.quantity = inner.quantity + locked_missiles
-                -- Update the min amount refilled by the reserve tank
-                RandomizerPowerup.SetItemAmount("ITEM_MISSILE_CHECK", inner.quantity)
             end
         end
     end
     RandomizerPowerup.OnPickedUp(progression)
     RandomizerPowerup.SetItemAmount("ITEM_MISSILE_TANKS", 0)
+    RandomizerPowerup.IncreaseMissileCheckValue()
 end

--- a/src/open_samus_returns_rando/files/pickups/randomizermissilelauncher.lua
+++ b/src/open_samus_returns_rando/files/pickups/randomizermissilelauncher.lua
@@ -10,6 +10,7 @@ function RandomizerMissileLauncher.OnPickedUp(progression)
             if inner.item_id == "ITEM_MISSILE_TANKS" then
                 inner.item_id = "ITEM_WEAPON_MISSILE_MAX"
                 inner.quantity = inner.quantity + locked_missiles
+                RandomizerPowerup.SetItemAmount("ITEM_MISSILE_CHECK", inner.quantity)
             end
         end
     end

--- a/src/open_samus_returns_rando/files/pickups/randomizermissilelauncher.lua
+++ b/src/open_samus_returns_rando/files/pickups/randomizermissilelauncher.lua
@@ -10,6 +10,7 @@ function RandomizerMissileLauncher.OnPickedUp(progression)
             if inner.item_id == "ITEM_MISSILE_TANKS" then
                 inner.item_id = "ITEM_WEAPON_MISSILE_MAX"
                 inner.quantity = inner.quantity + locked_missiles
+                -- Update the min amount refilled by the reserve tank
                 RandomizerPowerup.SetItemAmount("ITEM_MISSILE_CHECK", inner.quantity)
             end
         end

--- a/src/open_samus_returns_rando/files/pickups/randomizermissiletank.lua
+++ b/src/open_samus_returns_rando/files/pickups/randomizermissiletank.lua
@@ -17,6 +17,5 @@ function RandomizerMissileTank.OnPickedUp(progression)
         end
     end
     RandomizerPowerup.OnPickedUp(progression)
-    -- Update the min amount refilled by the reserve tank
-    RandomizerPowerup.SetItemAmount("ITEM_MISSILE_CHECK", RandomizerPowerup.GetItemAmount(new_item_id))
+    RandomizerPowerup.IncreaseMissileCheckValue()
 end

--- a/src/open_samus_returns_rando/files/pickups/randomizermissiletank.lua
+++ b/src/open_samus_returns_rando/files/pickups/randomizermissiletank.lua
@@ -17,4 +17,6 @@ function RandomizerMissileTank.OnPickedUp(progression)
         end
     end
     RandomizerPowerup.OnPickedUp(progression)
+    -- Update the min amount refilled by the reserve tank
+    RandomizerPowerup.SetItemAmount("ITEM_MISSILE_CHECK", RandomizerPowerup.GetItemAmount(new_item_id))
 end

--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -152,7 +152,7 @@
                 "missile_tank_size": {
                     "description": "How many Missiles are restored when using a Missile Reserve Tank",
                     "type": "number",
-                    "default": 50.0
+                    "default": 30.0
                 },
                 "super_missile_tank_size": {
                     "description": "How many Super Missiles are restored when using a Missile Reserve Tank",

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -142,3 +142,10 @@ function RandomizerPowerup.IncreaseAmmo(resource)
 
     RandomizerPowerup.IncreaseItemAmount(current_id, resource.quantity, resource.item_id)
 end
+
+function RandomizerPowerup.IncreaseMissileCheckValue()
+    -- Update the min refill amount of the missile reserve tank
+    if RandomizerPowerup.GetItemAmount("ITEM_MISSILE_CHECK") ~= nil then
+        RandomizerPowerup.SetItemAmount("ITEM_MISSILE_CHECK", RandomizerPowerup.GetItemAmount("ITEM_WEAPON_MISSILE_MAX"))
+    end
+end

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -144,7 +144,7 @@ function RandomizerPowerup.IncreaseAmmo(resource)
 end
 
 function RandomizerPowerup.IncreaseMissileCheckValue()
-    -- Update the min refill amount of the missile reserve tank
+    -- Update the min missile reserve tank refill value (capped by config)
     if RandomizerPowerup.GetItemAmount("ITEM_MISSILE_CHECK") ~= nil then
         RandomizerPowerup.SetItemAmount("ITEM_MISSILE_CHECK", RandomizerPowerup.GetItemAmount("ITEM_WEAPON_MISSILE_MAX"))
     end

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -215,7 +215,7 @@ class LuaEditor:
         if "ITEM_WEAPON_MISSILE_LAUNCHER" in inventory and "ITEM_MISSILE_TANKS" in inventory:
             inventory["ITEM_WEAPON_MISSILE_MAX"] = inventory.pop("ITEM_MISSILE_TANKS")
         else:
-            # For the gun component to work without launcher, any value is sufficient
+            # For the gun component to work without launcher, any value > 0 is sufficient
             inventory["ITEM_MISSILE_CHECK"] = 1
             samus_bmsad = editor.get_file(
                 "actors/characters/samus/charclasses/samus.bmsad", Bmsad

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -1,6 +1,7 @@
 import itertools
 
 from construct import Container
+from mercury_engine_data_structures.formats import Bmsad
 from mercury_engine_data_structures.formats.lua import Lua
 
 from open_samus_returns_rando.constants import ALL_SCENARIOS
@@ -213,6 +214,12 @@ class LuaEditor:
         # use _MAX if main is unlocked to unlock the ammo too
         if "ITEM_WEAPON_MISSILE_LAUNCHER" in inventory and "ITEM_MISSILE_TANKS" in inventory:
             inventory["ITEM_WEAPON_MISSILE_MAX"] = inventory.pop("ITEM_MISSILE_TANKS")
+        else:
+            # FIXME: Current implementation of shuffled launcher prevents missile reserve tank from restoring missiles
+            samus_bmsad = editor.get_file(
+                "actors/characters/samus/charclasses/samus.bmsad", Bmsad
+            )
+            samus_bmsad.raw["components"]["GUN"]["functions"][20]["params"]["Param5"]["value"] = ""
         if "ITEM_WEAPON_SUPER_MISSILE" in inventory and "ITEM_SUPER_MISSILE_TANKS" in inventory:
             inventory["ITEM_WEAPON_SUPER_MISSILE_MAX"] = inventory.pop("ITEM_SUPER_MISSILE_TANKS")
         if "ITEM_WEAPON_POWER_BOMB" in inventory and "ITEM_POWER_BOMB_TANKS" in inventory:

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -1,7 +1,6 @@
 import itertools
 
 from construct import Container
-from mercury_engine_data_structures.formats import Bmsad
 from mercury_engine_data_structures.formats.lua import Lua
 
 from open_samus_returns_rando.constants import ALL_SCENARIOS
@@ -214,13 +213,6 @@ class LuaEditor:
         # use _MAX if main is unlocked to unlock the ammo too
         if "ITEM_WEAPON_MISSILE_LAUNCHER" in inventory and "ITEM_MISSILE_TANKS" in inventory:
             inventory["ITEM_WEAPON_MISSILE_MAX"] = inventory.pop("ITEM_MISSILE_TANKS")
-        else:
-            # For the gun component to work without launcher, any value > 0 is sufficient
-            inventory["ITEM_MISSILE_CHECK"] = 1
-            samus_bmsad = editor.get_file(
-                "actors/characters/samus/charclasses/samus.bmsad", Bmsad
-            )
-            samus_bmsad.raw["components"]["GUN"]["functions"][20]["params"]["Param5"]["value"] = "ITEM_MISSILE_CHECK"
         if "ITEM_WEAPON_SUPER_MISSILE" in inventory and "ITEM_SUPER_MISSILE_TANKS" in inventory:
             inventory["ITEM_WEAPON_SUPER_MISSILE_MAX"] = inventory.pop("ITEM_SUPER_MISSILE_TANKS")
         if "ITEM_WEAPON_POWER_BOMB" in inventory and "ITEM_POWER_BOMB_TANKS" in inventory:
@@ -235,6 +227,7 @@ class LuaEditor:
             "ITEM_WEAPON_POWER_BOMB_MAX": 0,
             "ITEM_METROID_COUNT": 0,
             "ITEM_METROID_TOTAL_COUNT": 40,
+            "ITEM_MISSILE_CHECK": max(1, inventory.get("ITEM_WEAPON_MISSILE_MAX", 0)),
         }
         final_inventory.update(inventory)
 

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -197,6 +197,7 @@ class LuaEditor:
     def _create_custom_init(self, editor: PatcherEditor, configuration: dict) -> str:
         cosmetic_options: dict = configuration["cosmetic_patches"]
         inventory: dict[str, int] = configuration["starting_items"]
+        reserves_per_tank: dict = configuration["reserves_per_tank"]["missile_tank_size"]
         starting_location: dict = configuration["starting_location"]
         starting_text: list[str] = configuration.get("starting_text", [])
         configuration_identifier: str = configuration["configuration_identifier"]
@@ -216,10 +217,11 @@ class LuaEditor:
             inventory["ITEM_WEAPON_MISSILE_MAX"] = inventory.pop("ITEM_MISSILE_TANKS")
         else:
             # FIXME: Current implementation of shuffled launcher prevents missile reserve tank from restoring missiles
+            inventory["ITEM_MISSILE_CHECK"] = reserves_per_tank
             samus_bmsad = editor.get_file(
                 "actors/characters/samus/charclasses/samus.bmsad", Bmsad
             )
-            samus_bmsad.raw["components"]["GUN"]["functions"][20]["params"]["Param5"]["value"] = ""
+            samus_bmsad.raw["components"]["GUN"]["functions"][20]["params"]["Param5"]["value"] = "ITEM_MISSILE_CHECK"
         if "ITEM_WEAPON_SUPER_MISSILE" in inventory and "ITEM_SUPER_MISSILE_TANKS" in inventory:
             inventory["ITEM_WEAPON_SUPER_MISSILE_MAX"] = inventory.pop("ITEM_SUPER_MISSILE_TANKS")
         if "ITEM_WEAPON_POWER_BOMB" in inventory and "ITEM_POWER_BOMB_TANKS" in inventory:

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -197,7 +197,6 @@ class LuaEditor:
     def _create_custom_init(self, editor: PatcherEditor, configuration: dict) -> str:
         cosmetic_options: dict = configuration["cosmetic_patches"]
         inventory: dict[str, int] = configuration["starting_items"]
-        reserves_per_tank: dict = configuration["reserves_per_tank"]["missile_tank_size"]
         starting_location: dict = configuration["starting_location"]
         starting_text: list[str] = configuration.get("starting_text", [])
         configuration_identifier: str = configuration["configuration_identifier"]
@@ -216,8 +215,8 @@ class LuaEditor:
         if "ITEM_WEAPON_MISSILE_LAUNCHER" in inventory and "ITEM_MISSILE_TANKS" in inventory:
             inventory["ITEM_WEAPON_MISSILE_MAX"] = inventory.pop("ITEM_MISSILE_TANKS")
         else:
-            # FIXME: Current implementation of shuffled launcher prevents missile reserve tank from restoring missiles
-            inventory["ITEM_MISSILE_CHECK"] = reserves_per_tank
+            # For the gun component to work without launcher, any value is sufficient
+            inventory["ITEM_MISSILE_CHECK"] = 1
             samus_bmsad = editor.get_file(
                 "actors/characters/samus/charclasses/samus.bmsad", Bmsad
             )

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -72,6 +72,13 @@ def patch_a7_save_screw_blocks(editor: PatcherEditor):
     area7.raw["block_groups"][56]["types"][0]["block_type"] = "power_beam"
 
 
+def shoot_supers_without_missiles(editor: PatcherEditor):
+    samus_bmsad = editor.get_file(
+        "actors/characters/samus/charclasses/samus.bmsad", Bmsad
+    )
+    samus_bmsad.raw["components"]["GUN"]["functions"][20]["params"]["Param5"]["value"] = "ITEM_MISSILE_CHECK"
+
+
 def nerf_ridley_fight(editor: PatcherEditor):
     '''
     All beams (except Ice) will use the same factor as Plasma which is 0.12
@@ -186,6 +193,7 @@ def apply_static_fixes(editor: PatcherEditor):
     patch_pickup_position(editor)
     remove_area7_grapple_block(editor)
     patch_a7_save_screw_blocks(editor)
+    shoot_supers_without_missiles(editor)
     nerf_ridley_fight(editor)
     increase_pb_drop_chance(editor)
     fix_area2b_hp_item_001_deletion(editor)

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -72,14 +72,6 @@ def patch_a7_save_screw_blocks(editor: PatcherEditor):
     area7.raw["block_groups"][56]["types"][0]["block_type"] = "power_beam"
 
 
-def shoot_supers_without_missiles(editor: PatcherEditor):
-    samus = editor.get_file(
-        "actors/characters/samus/charclasses/samus.bmsad", Bmsad
-    )
-    gun = samus.raw["components"]["GUN"]["functions"]
-    gun[20]["params"]["Param5"]["value"] = ""
-
-
 def nerf_ridley_fight(editor: PatcherEditor):
     '''
     All beams (except Ice) will use the same factor as Plasma which is 0.12
@@ -194,7 +186,6 @@ def apply_static_fixes(editor: PatcherEditor):
     patch_pickup_position(editor)
     remove_area7_grapple_block(editor)
     patch_a7_save_screw_blocks(editor)
-    shoot_supers_without_missiles(editor)
     nerf_ridley_fight(editor)
     increase_pb_drop_chance(editor)
     fix_area2b_hp_item_001_deletion(editor)


### PR DESCRIPTION
- Move Launcher Shuffle to `lua_editor`
- Fix default `missiles_per_tank` count
- ~~Disable gun component only if shuffled launcher~~

~~The bug in #276 still exists with this fix, but this at least makes the Missile Reserve Tank fully usable if starting with Missile Launcher. Dunno if we should try to fully fix this in this PR to make it work with shuffled launcher, or just throw a warning in RDV that this bug exists and merge this one for now.~~