### PR TITLE
Only enable Missile Reserve Tank if Missile Launcher is in inventory

### DIFF
--- a/src/open_samus_returns_rando/files/pickups/randomizermissilelauncher.lua
+++ b/src/open_samus_returns_rando/files/pickups/randomizermissilelauncher.lua
@@ -16,4 +16,7 @@ function RandomizerMissileLauncher.OnPickedUp(progression)
     RandomizerPowerup.OnPickedUp(progression)
     RandomizerPowerup.SetItemAmount("ITEM_MISSILE_TANKS", 0)
     RandomizerPowerup.IncreaseMissileCheckValue()
+    if RandomizerPowerup.GetItemAmount("ITEM_RESERVE_TANK_MISSILE") > 0 then
+        RandomizerPowerup.EnableMissileReserveTank()
+    end
 end

--- a/src/open_samus_returns_rando/files/pickups/randomizerreservetankm.lua
+++ b/src/open_samus_returns_rando/files/pickups/randomizerreservetankm.lua
@@ -5,8 +5,7 @@ end
 
 function RandomizerReserveTankM.OnPickedUp(progression)
     RandomizerPowerup.OnPickedUp(progression)
-    Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_MISSILE_ACTIVE", "b", true)
-    Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_MISSILE_FULL", "b", true)
-    Game.AddSF(0.0, "Game.HUDIdleScreenGo", "")
-    Game.AddSF(0.5, "Game.HUDIdleScreenLeave", "")
+    if RandomizerPowerup.GetItemAmount("ITEM_WEAPON_MISSILE_LAUNCHER") > 0 then
+        RandomizerPowerup.EnableMissileReserveTank()
+    end
 end

--- a/src/open_samus_returns_rando/files/templates/custom_init.lua
+++ b/src/open_samus_returns_rando/files/templates/custom_init.lua
@@ -24,7 +24,7 @@ function Init.InitGameBlackboard()
       Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_ADN", "f", current_amount + 1)
     end
     if string.sub(_FORV_3_, 1, 17) == "ITEM_RESERVE_TANK" then
-      if (_FORV_3_ == "ITEM_RESERVE_TANK_MISSILE" and Blackboard.GetProp("PLAYER_INVENTORY", "ITEM_WEAPON_MISSILE_LAUNCHER")) or _FORV_3_ ~= "ITEM_RESERVE_TANK_MISSILE" then
+      if _FORV_3_ ~= "ITEM_RESERVE_TANK_MISSILE" or Blackboard.GetProp("PLAYER_INVENTORY", "ITEM_WEAPON_MISSILE_LAUNCHER") then
         Blackboard.SetProp("GAME", _FORV_3_ .. "_ACTIVE", "b", true)
         Blackboard.SetProp("GAME", _FORV_3_ .. "_FULL", "b", true)
       end

--- a/src/open_samus_returns_rando/files/templates/custom_init.lua
+++ b/src/open_samus_returns_rando/files/templates/custom_init.lua
@@ -24,10 +24,7 @@ function Init.InitGameBlackboard()
       Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_ADN", "f", current_amount + 1)
     end
     if string.sub(_FORV_3_, 1, 17) == "ITEM_RESERVE_TANK" then
-      if _FORV_3_ == "ITEM_RESERVE_TANK_MISSILE" and Blackboard.GetProp("PLAYER_INVENTORY", "ITEM_WEAPON_MISSILE_LAUNCHER") then
-        Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_MISSILE_ACTIVE", "b", true)
-        Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_MISSILE_FULL", "b", true)
-      elseif _FORV_3_ ~= "ITEM_RESERVE_TANK_MISSILE" then
+      if (_FORV_3_ == "ITEM_RESERVE_TANK_MISSILE" and Blackboard.GetProp("PLAYER_INVENTORY", "ITEM_WEAPON_MISSILE_LAUNCHER")) or _FORV_3_ ~= "ITEM_RESERVE_TANK_MISSILE" then
         Blackboard.SetProp("GAME", _FORV_3_ .. "_ACTIVE", "b", true)
         Blackboard.SetProp("GAME", _FORV_3_ .. "_FULL", "b", true)
       end

--- a/src/open_samus_returns_rando/files/templates/custom_init.lua
+++ b/src/open_samus_returns_rando/files/templates/custom_init.lua
@@ -24,8 +24,13 @@ function Init.InitGameBlackboard()
       Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_ADN", "f", current_amount + 1)
     end
     if string.sub(_FORV_3_, 1, 17) == "ITEM_RESERVE_TANK" then
-      Blackboard.SetProp("GAME", _FORV_3_ .. "_ACTIVE", "b", true)
-      Blackboard.SetProp("GAME", _FORV_3_ .. "_FULL", "b", true)
+      if _FORV_3_ == "ITEM_RESERVE_TANK_MISSILE" and Blackboard.GetProp("PLAYER_INVENTORY", "ITEM_WEAPON_MISSILE_LAUNCHER") then
+        Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_MISSILE_ACTIVE", "b", true)
+        Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_MISSILE_FULL", "b", true)
+      elseif _FORV_3_ ~= "ITEM_RESERVE_TANK_MISSILE" then
+        Blackboard.SetProp("GAME", _FORV_3_ .. "_ACTIVE", "b", true)
+        Blackboard.SetProp("GAME", _FORV_3_ .. "_FULL", "b", true)
+      end
     end
   end
   Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_METROID_COUNT", "f", 0)

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -149,3 +149,10 @@ function RandomizerPowerup.IncreaseMissileCheckValue()
         RandomizerPowerup.SetItemAmount("ITEM_MISSILE_CHECK", RandomizerPowerup.GetItemAmount("ITEM_WEAPON_MISSILE_MAX"))
     end
 end
+
+function RandomizerPowerup.EnableMissileReserveTank()
+    Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_MISSILE_ACTIVE", "b", true)
+    Blackboard.SetProp("GAME", "ITEM_RESERVE_TANK_MISSILE_FULL", "b", true)
+    Game.AddSF(0.0, "Game.HUDIdleScreenGo", "")
+    Game.AddSF(0.5, "Game.HUDIdleScreenLeave", "")
+end


### PR DESCRIPTION
Given the current implementation of shuffled Missile Launcher, this is the simplest solution to preventing the Missile Reserve Tank from activating on its own without Missiles. Now, it checks for Missile Launcher in the inventory to activate. The only downside is that having only Super Launcher means you can't utilize the Reserve Tank to your advantage. Maybe in the future we can have the Reserve Tank be independent of the Launcher, but this is the best option I'm willing to take for now.

Fixes #253