### PR TITLE
Proper fix multis

### DIFF
--- a/src/open_samus_returns_rando/files/custom/scenario.lua
+++ b/src/open_samus_returns_rando/files/custom/scenario.lua
@@ -45,7 +45,6 @@ end
 function Scenario.SetMetroidSpawngroupOnCurrentScenario(created_actor, group_name, is_multi)
   if created_actor ~= nil and created_actor.sName ~= nil then
     CurrentScenario.currentMetroidSpawngroup = group_name
-    CurrentScenario.isMultiGamma = is_multi or false
   end
 end
 

--- a/src/open_samus_returns_rando/files/custom/scenario.lua
+++ b/src/open_samus_returns_rando/files/custom/scenario.lua
@@ -42,7 +42,7 @@ function Scenario.OnSubAreaChange(old_subarea, old_actorgroup, new_subarea, new_
   Scenario.UpdateRoomName(new_subarea)
 end
 
-function Scenario.SetMetroidSpawngroupOnCurrentScenario(created_actor, group_name, is_multi)
+function Scenario.SetMetroidSpawngroupOnCurrentScenario(created_actor, group_name)
   if created_actor ~= nil and created_actor.sName ~= nil then
     CurrentScenario.currentMetroidSpawngroup = group_name
   end

--- a/src/open_samus_returns_rando/files/levels/s030_area3.lua
+++ b/src/open_samus_returns_rando/files/levels/s030_area3.lua
@@ -10,122 +10,124 @@ function s030_area3.GetOnDeathOverrides()
   return {GoToMainMenu = false}
 end
 function s030_area3.OnEnter_SetCheckpoint_Gamma_005()
-  Game.SetBossCheckPointNames("ST_SG_Gamma_005", "ST_SG_Gamma_005", "SG_Gamma_005_A", "SG_Gamma_005_B", "SG_Gamma_005_C")
+  Game.SetBossCheckPointNames("ST_SG_Gamma_005", "ST_SG_Gamma_005", "", "", "SG_Gamma_005_C")
 end
-function s030_area3.OnGamma_005_A_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_005", "A")
-end
-function s030_area3.OnGamma_005_Intro_A_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_005_Intro_A") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_005_Intro_A").ANIMATION:SetAction("spawn")
-  end
-  s030_area3.OnGamma_005_A_Generated(_ARG_0_, _ARG_1_)
-end
-function s030_area3.OnGamma_005_A_Generated(_ARG_0_, _ARG_1_)
-  if _ARG_1_ ~= nil then
-    -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door015")
-    _ARG_1_.AI.bPlaceholder = false
-    _ARG_1_.AI:AddBossCamera("CAM_Gamma")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma005_A_001")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma005_A_002")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma005_A_003")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_A_001")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_A_002")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_A_003")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma005_A_001")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma005_A_002")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma005_A_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_A_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_A_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_A_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_A_mines_004")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_A_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_A_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_A_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_A_mines_004")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_A_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_A_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_A_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_A_mines_004")
-    _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma005_A_Idle")
-    Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
-    if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_A_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_A_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-    if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_A_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_A_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-  end
-end
-function s030_area3.OnGamma_005_B_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_005", "B")
-end
-function s030_area3.OnGamma_005_Intro_B_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_005_Intro_B") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_005_Intro_B").ANIMATION:SetAction("spawn")
-  end
-  s030_area3.OnGamma_005_B_Generated(_ARG_0_, _ARG_1_)
-end
-function s030_area3.OnGamma_005_B_Generated(_ARG_0_, _ARG_1_)
-  if _ARG_1_ ~= nil then
-    -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door015")
-    _ARG_1_.AI.bPlaceholder = false
-    _ARG_1_.AI:AddBossCamera("CAM_Gamma")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma005_B_001")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma005_B_002")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma005_B_003")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_B_001")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_B_002")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_B_003")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma005_B_001")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma005_B_002")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_B_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_B_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_B_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_B_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_B_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_B_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_B_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_B_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_B_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_B_mines_003")
-    _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma005_B_Idle")
-    Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
-    if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_B_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_B_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-    if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_B_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_B_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-  end
-end
+-- function s030_area3.OnGamma_005_A_Trigger()
+--   Gamma.OnMultiArenaTrigger("Gamma_005", "A")
+-- end
+-- function s030_area3.OnGamma_005_Intro_A_Generated(_ARG_0_, _ARG_1_)
+--   if Game.GetEntity("LE_Valve_Gamma_005_Intro_A") ~= nil then
+--     Game.GetEntity("LE_Valve_Gamma_005_Intro_A").ANIMATION:SetAction("spawn")
+--   end
+--   s030_area3.OnGamma_005_A_Generated(_ARG_0_, _ARG_1_)
+-- end
+-- function s030_area3.OnGamma_005_A_Generated(_ARG_0_, _ARG_1_)
+--   if _ARG_1_ ~= nil then
+--     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door015")
+--     _ARG_1_.AI.bPlaceholder = false
+--     _ARG_1_.AI:AddBossCamera("CAM_Gamma")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma005_A_001")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma005_A_002")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma005_A_003")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_A_001")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_A_002")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_A_003")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma005_A_001")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma005_A_002")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma005_A_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_A_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_A_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_A_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_A_mines_004")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_A_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_A_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_A_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_A_mines_004")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_A_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_A_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_A_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_A_mines_004")
+--     _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma005_A_Idle")
+--     Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_A_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_A_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_A_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_A_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--   end
+-- end
+-- function s030_area3.OnGamma_005_B_Trigger()
+--   Gamma.OnMultiArenaTrigger("Gamma_005", "B")
+-- end
+-- function s030_area3.OnGamma_005_Intro_B_Generated(_ARG_0_, _ARG_1_)
+--   if Game.GetEntity("LE_Valve_Gamma_005_Intro_B") ~= nil then
+--     Game.GetEntity("LE_Valve_Gamma_005_Intro_B").ANIMATION:SetAction("spawn")
+--   end
+--   s030_area3.OnGamma_005_B_Generated(_ARG_0_, _ARG_1_)
+-- end
+-- function s030_area3.OnGamma_005_B_Generated(_ARG_0_, _ARG_1_)
+--   if _ARG_1_ ~= nil then
+--     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door015")
+--     _ARG_1_.AI.bPlaceholder = false
+--     _ARG_1_.AI:AddBossCamera("CAM_Gamma")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma005_B_001")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma005_B_002")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma005_B_003")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_B_001")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_B_002")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_B_003")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma005_B_001")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma005_B_002")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma005_B_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_B_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_B_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma005_B_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_B_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_B_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma005_B_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_B_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_B_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma005_B_mines_003")
+--     _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma005_B_Idle")
+--     Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_B_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_B_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_B_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_005_B_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--   end
+-- end
 function s030_area3.OnGamma_005_C_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_005", "C")
+  if Game.GetEntity("SG_Gamma_005_C") ~= nil then
+    Game.GetEntity("SG_Gamma_005_C").SPAWNGROUP:EnableSpawnGroup()
+  end
 end
 function s030_area3.OnGamma_005_Intro_C_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_005_C_002") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_005_C_002").ANIMATION:SetAction("spawn")
-  end
+  -- if Game.GetEntity("LE_Valve_Gamma_005_C_002") ~= nil then
+  --   Game.GetEntity("LE_Valve_Gamma_005_C_002").ANIMATION:SetAction("spawn")
+  -- end
   s030_area3.OnGamma_005_C_Generated(_ARG_0_, _ARG_1_)
 end
 function s030_area3.OnGamma_005_C_Generated(_ARG_0_, _ARG_1_)
-  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_005_C", true)
+  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_005_C")
   if _ARG_1_ ~= nil then
     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door015")
     _ARG_1_.AI.bPlaceholder = false

--- a/src/open_samus_returns_rando/files/levels/s030_area3.lua
+++ b/src/open_samus_returns_rando/files/levels/s030_area3.lua
@@ -116,7 +116,7 @@ end
 --   end
 -- end
 function s030_area3.OnGamma_005_C_Trigger()
-  if Game.GetEntity("SG_Gamma_005_C") ~= nil then
+  if Game.GetEntity("SG_Gamma_005_C") ~= nil and Scenario.ReadFromBlackboard("entity_TG_Gamma_005_C_enabled", true) then
     Game.GetEntity("SG_Gamma_005_C").SPAWNGROUP:EnableSpawnGroup()
   end
 end

--- a/src/open_samus_returns_rando/files/levels/s033_area3b.lua
+++ b/src/open_samus_returns_rando/files/levels/s033_area3b.lua
@@ -396,7 +396,7 @@ end
 --   end
 -- end
 function s033_area3b.OnGamma_004_B_Trigger()
-  if Game.GetEntity("SG_Gamma_004_B") ~= nil then
+  if Game.GetEntity("SG_Gamma_004_B") ~= nil and Scenario.ReadFromBlackboard("entity_TG_Gamma_004_B_enabled", true) then
     Game.GetEntity("SG_Gamma_004_B").SPAWNGROUP:EnableSpawnGroup()
   end
 end

--- a/src/open_samus_returns_rando/files/levels/s033_area3b.lua
+++ b/src/open_samus_returns_rando/files/levels/s033_area3b.lua
@@ -343,69 +343,71 @@ function s033_area3b.OnEnter_Gamma_003_DisableAttack()
   end
 end
 function s033_area3b.OnEnter_SetCheckpoint_Gamma_004()
-  Game.SetBossCheckPointNames("ST_SG_Gamma_004", "ST_SG_Gamma_004", "SG_Gamma_004_A", "SG_Gamma_004_B", "SG_Gamma_004_C")
+  Game.SetBossCheckPointNames("ST_SG_Gamma_004", "ST_SG_Gamma_004", "", "SG_Gamma_004_B", "")
 end
-function s033_area3b.OnGamma_004_A_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_004", "A")
-end
-function s033_area3b.OnGamma_004_Intro_A_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_004_Intro_A") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_004_Intro_A").ANIMATION:SetAction("spawn")
-  end
-  s033_area3b.OnGamma_004_A_Generated(_ARG_0_, _ARG_1_)
-end
-function s033_area3b.OnGamma_004_A_Generated(_ARG_0_, _ARG_1_)
-  if _ARG_1_ ~= nil then
-    -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door014")
-    _ARG_1_.AI.bPlaceholder = false
-    _ARG_1_.AI:AddBossCamera("CAM_Gamma")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma004_A_001")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma004_A_002")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma004_A_003")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma004_A_001")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma004_A_002")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma004_A_003")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma004_A_001")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma004_A_002")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma004_A_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma004_A_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma004_A_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma004_A_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma004_A_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma004_A_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma004_A_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma004_A_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma004_A_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma004_A_mines_003")
-    _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma004_A_Idle")
-    Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
-    if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_A_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_A_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-    if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_A_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_A_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-  end
-end
+-- function s033_area3b.OnGamma_004_A_Trigger()
+--   Gamma.OnMultiArenaTrigger("Gamma_004", "A")
+-- end
+-- function s033_area3b.OnGamma_004_Intro_A_Generated(_ARG_0_, _ARG_1_)
+--   if Game.GetEntity("LE_Valve_Gamma_004_Intro_A") ~= nil then
+--     Game.GetEntity("LE_Valve_Gamma_004_Intro_A").ANIMATION:SetAction("spawn")
+--   end
+--   s033_area3b.OnGamma_004_A_Generated(_ARG_0_, _ARG_1_)
+-- end
+-- function s033_area3b.OnGamma_004_A_Generated(_ARG_0_, _ARG_1_)
+--   if _ARG_1_ ~= nil then
+--     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door014")
+--     _ARG_1_.AI.bPlaceholder = false
+--     _ARG_1_.AI:AddBossCamera("CAM_Gamma")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma004_A_001")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma004_A_002")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma004_A_003")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma004_A_001")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma004_A_002")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma004_A_003")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma004_A_001")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma004_A_002")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma004_A_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma004_A_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma004_A_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma004_A_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma004_A_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma004_A_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma004_A_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma004_A_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma004_A_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma004_A_mines_003")
+--     _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma004_A_Idle")
+--     Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_A_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_A_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_A_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_A_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--   end
+-- end
 function s033_area3b.OnGamma_004_B_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_004", "B")
+  if Game.GetEntity("SG_Gamma_004_B") ~= nil then
+    Game.GetEntity("SG_Gamma_004_B").SPAWNGROUP:EnableSpawnGroup()
+  end
 end
 function s033_area3b.OnGamma_004_Intro_B_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_004_Intro_B") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_004_Intro_B").ANIMATION:SetAction("spawn")
-  end
+  -- if Game.GetEntity("LE_Valve_Gamma_004_Intro_B") ~= nil then
+  --   Game.GetEntity("LE_Valve_Gamma_004_Intro_B").ANIMATION:SetAction("spawn")
+  -- end
   s033_area3b.OnGamma_004_B_Generated(_ARG_0_, _ARG_1_)
 end
 function s033_area3b.OnGamma_004_B_Generated(_ARG_0_, _ARG_1_)
-  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_004_B", true)
+  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_004_B")
   if _ARG_1_ ~= nil then
     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door014")
     _ARG_1_.AI.bPlaceholder = false
@@ -446,56 +448,56 @@ function s033_area3b.OnGamma_004_B_Generated(_ARG_0_, _ARG_1_)
     -- end
   end
 end
-function s033_area3b.OnGamma_004_C_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_004", "C")
-end
-function s033_area3b.OnGamma_004_Intro_C_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_004_Intro_C") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_004_Intro_C").ANIMATION:SetAction("spawn")
-  end
-  s033_area3b.OnGamma_004_C_Generated(_ARG_0_, _ARG_1_)
-end
-function s033_area3b.OnGamma_004_C_Generated(_ARG_0_, _ARG_1_)
-  if _ARG_1_ ~= nil then
-    -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door014")
-    _ARG_1_.AI.bPlaceholder = false
-    _ARG_1_.AI:AddBossCamera("CAM_Gamma")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma004_C_001")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma004_C_002")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma004_C_003")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma004_C_001")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma004_C_002")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma004_C_003")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma004_C_001")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma004_C_002")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma004_C_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma004_C_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma004_C_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma004_C_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma004_C_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma004_C_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma004_C_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma004_C_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma004_C_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma004_C_mines_003")
-    _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma004_C_Idle")
-    Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
-    if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_C_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_C_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-    if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_C_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_C_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-  end
-end
+-- function s033_area3b.OnGamma_004_C_Trigger()
+--   Gamma.OnMultiArenaTrigger("Gamma_004", "C")
+-- end
+-- function s033_area3b.OnGamma_004_Intro_C_Generated(_ARG_0_, _ARG_1_)
+--   if Game.GetEntity("LE_Valve_Gamma_004_Intro_C") ~= nil then
+--     Game.GetEntity("LE_Valve_Gamma_004_Intro_C").ANIMATION:SetAction("spawn")
+--   end
+--   s033_area3b.OnGamma_004_C_Generated(_ARG_0_, _ARG_1_)
+-- end
+-- function s033_area3b.OnGamma_004_C_Generated(_ARG_0_, _ARG_1_)
+--   if _ARG_1_ ~= nil then
+--     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door014")
+--     _ARG_1_.AI.bPlaceholder = false
+--     _ARG_1_.AI:AddBossCamera("CAM_Gamma")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma004_C_001")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma004_C_002")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma004_C_003")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma004_C_001")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma004_C_002")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma004_C_003")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma004_C_001")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma004_C_002")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma004_C_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma004_C_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma004_C_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma004_C_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma004_C_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma004_C_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma004_C_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma004_C_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma004_C_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma004_C_mines_003")
+--     _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma004_C_Idle")
+--     Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_C_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_C_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_C_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_004_C_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--   end
+-- end
 function s033_area3b.OnEnter_Gamma_004_Dead()
   if Scenario.ReadFromBlackboard("Arena_Gamma_004_AllDead", false) then
     Game.SetSubAreaCurrentSetup("collision_camera_033", "PostGamma_004", true)

--- a/src/open_samus_returns_rando/files/levels/s036_area3c.lua
+++ b/src/open_samus_returns_rando/files/levels/s036_area3c.lua
@@ -213,7 +213,7 @@ function s036_area3c.OnEnter_Gamma_006_Dead()
   end
 end
 function s036_area3c.OnGamma_007_A_Trigger()
-  if Game.GetEntity("SG_Gamma_007_A") ~= nil then
+  if Game.GetEntity("SG_Gamma_007_A") ~= nil and Scenario.ReadFromBlackboard("entity_TG_Gamma_007_A_enabled", true) then
     Game.GetEntity("SG_Gamma_007_A").SPAWNGROUP:EnableSpawnGroup()
   end
 end

--- a/src/open_samus_returns_rando/files/levels/s036_area3c.lua
+++ b/src/open_samus_returns_rando/files/levels/s036_area3c.lua
@@ -213,19 +213,21 @@ function s036_area3c.OnEnter_Gamma_006_Dead()
   end
 end
 function s036_area3c.OnGamma_007_A_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_007", "A")
+  if Game.GetEntity("SG_Gamma_007_A") ~= nil then
+    Game.GetEntity("SG_Gamma_007_A").SPAWNGROUP:EnableSpawnGroup()
+  end
 end
 function s036_area3c.OnGamma_007_Intro_A_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_007_Intro_A") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_007_Intro_A").ANIMATION:SetAction("spawn")
-  end
+  -- if Game.GetEntity("LE_Valve_Gamma_007_Intro_A") ~= nil then
+  --   Game.GetEntity("LE_Valve_Gamma_007_Intro_A").ANIMATION:SetAction("spawn")
+  -- end
   s036_area3c.OnGamma_007_A_Generated(_ARG_0_, _ARG_1_)
 end
 function s036_area3c.OnEnter_SetCheckpoint_001_Gamma_007()
-  Game.SetBossCheckPointNames("ST_SG_Gamma_007", "ST_SG_Gamma_007", "SG_Gamma_007_A", "SG_Gamma_007_B", "SG_Gamma_007_C")
+  Game.SetBossCheckPointNames("ST_SG_Gamma_007", "ST_SG_Gamma_007", "SG_Gamma_007_A", "", "")
 end
 function s036_area3c.OnGamma_007_A_Generated(_ARG_0_, _ARG_1_)
-  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_007_A", true)
+  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_007_A")
   if _ARG_1_ ~= nil then
     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door006")
     _ARG_1_.AI.bPlaceholder = false
@@ -270,57 +272,57 @@ function s036_area3c.OnGamma_007_A_Generated(_ARG_0_, _ARG_1_)
     -- end
   end
 end
-function s036_area3c.OnGamma_007_B_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_007", "B")
-end
-function s036_area3c.OnGamma_007_Intro_B_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_007_Intro_B") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_007_Intro_B").ANIMATION:SetAction("spawn")
-  end
-  s036_area3c.OnGamma_007_B_Generated(_ARG_0_, _ARG_1_)
-end
-function s036_area3c.OnGamma_007_B_Generated(_ARG_0_, _ARG_1_)
-  if _ARG_1_ ~= nil then
-    -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door006")
-    _ARG_1_.AI.bPlaceholder = false
-    _ARG_1_.AI:AddBossCamera("CAM_Gamma")
-    _ARG_1_.AI:AddBossCameraCeilingLandmark("LM_Gamma_007B_Ceiling")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma007_B_001")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma007_B_002")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma007_B_003")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma007_B_001")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma007_B_002")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma007_B_003")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma007_B_001")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma007_B_002")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma007_B_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma007_B_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma007_B_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma007_B_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma007_B_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma007_B_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma007_B_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma007_B_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma007_B_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma007_B_mines_003")
-    _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma007_B_Idle")
-    Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
-    if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_007_B_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_007_B_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-    if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_007_B_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_007_B_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-  end
-end
+-- function s036_area3c.OnGamma_007_B_Trigger()
+--   Gamma.OnMultiArenaTrigger("Gamma_007", "B")
+-- end
+-- function s036_area3c.OnGamma_007_Intro_B_Generated(_ARG_0_, _ARG_1_)
+--   if Game.GetEntity("LE_Valve_Gamma_007_Intro_B") ~= nil then
+--     Game.GetEntity("LE_Valve_Gamma_007_Intro_B").ANIMATION:SetAction("spawn")
+--   end
+--   s036_area3c.OnGamma_007_B_Generated(_ARG_0_, _ARG_1_)
+-- end
+-- function s036_area3c.OnGamma_007_B_Generated(_ARG_0_, _ARG_1_)
+--   if _ARG_1_ ~= nil then
+--     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door006")
+--     _ARG_1_.AI.bPlaceholder = false
+--     _ARG_1_.AI:AddBossCamera("CAM_Gamma")
+--     _ARG_1_.AI:AddBossCameraCeilingLandmark("LM_Gamma_007B_Ceiling")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma007_B_001")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma007_B_002")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma007_B_003")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma007_B_001")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma007_B_002")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma007_B_003")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma007_B_001")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma007_B_002")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma007_B_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma007_B_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma007_B_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma007_B_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma007_B_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma007_B_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma007_B_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma007_B_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma007_B_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma007_B_mines_003")
+--     _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma007_B_Idle")
+--     Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_007_B_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_007_B_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_007_B_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_007_B_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--   end
+-- end
 function s036_area3c.OnEnter_Gamma_007_Dead()
   if Scenario.ReadFromBlackboard("Arena_Gamma_007_AllDead", false) then
     Game.SetSubAreaCurrentSetup("collision_camera_013", "PostGamma_007", true)

--- a/src/open_samus_returns_rando/files/levels/s036_area3c.lua
+++ b/src/open_samus_returns_rando/files/levels/s036_area3c.lua
@@ -204,7 +204,7 @@ function s036_area3c.OnGamma_006_Generated(_ARG_0_, _ARG_1_)
   end
 end
 function s036_area3c.OnEnter_Gamma_006_Dead()
-  if 0 < Scenario.ReadFromBlackboard("entity_SG_Gamma_006_deaths", 0) and Scenario.ReadFromBlackboard("Arena_Gamma_007_AllDead", false) then
+  if 0 < Scenario.ReadFromBlackboard("entity_SG_Gamma_006_deaths", 0) then
     Game.SetSubAreaCurrentSetup("collision_camera_023", "PostGamma_006", true)
     Game.SetSubAreaCurrentSetup("collision_camera_030", "PostGamma_006", true)
     if Game.GetEntity("SpawnGroup007") ~= nil then

--- a/src/open_samus_returns_rando/files/levels/s040_area4.lua
+++ b/src/open_samus_returns_rando/files/levels/s040_area4.lua
@@ -44,19 +44,21 @@ function s040_area4.OnEnter_Alpha_001_Dead()
   end
 end
 function s040_area4.OnEnter_SetCheckpoint_Gamma_001()
-  Game.SetBossCheckPointNames("ST_SG_Gamma_001", "ST_SG_Gamma_001", "SG_Gamma_001_A", "SG_Gamma_001_B", "SG_Gamma_001_C")
+  Game.SetBossCheckPointNames("ST_SG_Gamma_001", "ST_SG_Gamma_001", "SG_Gamma_001_A", "", "")
 end
 function s040_area4.OnGamma_001_A_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_001", "A")
+  if Game.GetEntity("SG_Gamma_001_A") ~= nil then
+    Game.GetEntity("SG_Gamma_001_A").SPAWNGROUP:EnableSpawnGroup()
+  end
 end
 function s040_area4.OnGamma_001_Intro_A_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_001_Intro_A") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_001_Intro_A").ANIMATION:SetAction("spawn")
-  end
+  -- if Game.GetEntity("LE_Valve_Gamma_001_Intro_A") ~= nil then
+  --   Game.GetEntity("LE_Valve_Gamma_001_Intro_A").ANIMATION:SetAction("spawn")
+  -- end
   s040_area4.OnGamma_001_A_Generated(_ARG_0_, _ARG_1_)
 end
 function s040_area4.OnGamma_001_A_Generated(_ARG_0_, _ARG_1_)
-  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_001_A", true)
+  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_001_A")
   if _ARG_1_ ~= nil then
     -- _ARG_1_.AI:AddBossDoor("Door011")
     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door004")
@@ -99,108 +101,108 @@ function s040_area4.OnGamma_001_A_Generated(_ARG_0_, _ARG_1_)
     -- end
   end
 end
-function s040_area4.OnGamma_001_B_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_001", "B")
-end
-function s040_area4.OnGamma_001_Intro_B_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_001_B_002") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_001_B_002").ANIMATION:SetAction("spawn")
-  end
-  s040_area4.OnGamma_001_B_Generated(_ARG_0_, _ARG_1_)
-end
-function s040_area4.OnGamma_001_B_Generated(_ARG_0_, _ARG_1_)
-  if _ARG_1_ ~= nil then
-    -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door004")
-    _ARG_1_.AI.bPlaceholder = false
-    _ARG_1_.AI:AddBossCamera("CAM_Gamma")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma001_B_001")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma001_B_002")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma001_B_003")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma001_B_001")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma001_B_002")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma001_B_003")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma001_B_001")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma001_B_002")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma001_B_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma001_B_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma001_B_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma001_B_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma001_B_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma001_B_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma001_B_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma001_B_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma001_B_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma001_B_mines_003")
-    _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma001_B_Idle")
-    Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
-    if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_B_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_B_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-    if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_B_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_B_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-  end
-end
-function s040_area4.OnGamma_001_C_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_001", "C")
-end
-function s040_area4.OnGamma_001_Intro_C_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_001_Intro_C") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_001_Intro_C").ANIMATION:SetAction("spawn")
-  end
-  s040_area4.OnGamma_001_C_Generated(_ARG_0_, _ARG_1_)
-end
-function s040_area4.OnGamma_001_C_Generated(_ARG_0_, _ARG_1_)
-  if _ARG_1_ ~= nil then
-    -- _ARG_1_.AI:AddBossDoor("Door010")
-    -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door004")
-    _ARG_1_.AI.bPlaceholder = false
-    _ARG_1_.AI:AddBossCamera("CAM_Gamma")
-    _ARG_1_.AI:AddBossCameraFloorLandmark("LM_Gamma_001_C")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma001_C_001")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma001_C_002")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma001_C_003")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma001_C_001")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma001_C_002")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma001_C_003")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma001_C_001")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma001_C_002")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma001_C_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma001_C_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma001_C_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma001_C_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma001_C_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma001_C_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma001_C_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma001_C_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma001_C_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma001_C_mines_003")
-    _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma001_C_Idle")
-    Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
-    if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_C_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_C_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-    if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_C_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_C_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-  end
-end
+-- function s040_area4.OnGamma_001_B_Trigger()
+--   Gamma.OnMultiArenaTrigger("Gamma_001", "B")
+-- end
+-- function s040_area4.OnGamma_001_Intro_B_Generated(_ARG_0_, _ARG_1_)
+--   if Game.GetEntity("LE_Valve_Gamma_001_B_002") ~= nil then
+--     Game.GetEntity("LE_Valve_Gamma_001_B_002").ANIMATION:SetAction("spawn")
+--   end
+--   s040_area4.OnGamma_001_B_Generated(_ARG_0_, _ARG_1_)
+-- end
+-- function s040_area4.OnGamma_001_B_Generated(_ARG_0_, _ARG_1_)
+--   if _ARG_1_ ~= nil then
+--     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door004")
+--     _ARG_1_.AI.bPlaceholder = false
+--     _ARG_1_.AI:AddBossCamera("CAM_Gamma")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma001_B_001")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma001_B_002")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma001_B_003")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma001_B_001")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma001_B_002")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma001_B_003")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma001_B_001")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma001_B_002")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma001_B_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma001_B_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma001_B_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma001_B_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma001_B_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma001_B_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma001_B_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma001_B_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma001_B_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma001_B_mines_003")
+--     _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma001_B_Idle")
+--     Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_B_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_B_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_B_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_B_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--   end
+-- end
+-- function s040_area4.OnGamma_001_C_Trigger()
+--   Gamma.OnMultiArenaTrigger("Gamma_001", "C")
+-- end
+-- function s040_area4.OnGamma_001_Intro_C_Generated(_ARG_0_, _ARG_1_)
+--   if Game.GetEntity("LE_Valve_Gamma_001_Intro_C") ~= nil then
+--     Game.GetEntity("LE_Valve_Gamma_001_Intro_C").ANIMATION:SetAction("spawn")
+--   end
+--   s040_area4.OnGamma_001_C_Generated(_ARG_0_, _ARG_1_)
+-- end
+-- function s040_area4.OnGamma_001_C_Generated(_ARG_0_, _ARG_1_)
+--   if _ARG_1_ ~= nil then
+--     -- _ARG_1_.AI:AddBossDoor("Door010")
+--     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door004")
+--     _ARG_1_.AI.bPlaceholder = false
+--     _ARG_1_.AI:AddBossCamera("CAM_Gamma")
+--     _ARG_1_.AI:AddBossCameraFloorLandmark("LM_Gamma_001_C")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma001_C_001")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma001_C_002")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma001_C_003")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma001_C_001")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma001_C_002")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma001_C_003")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma001_C_001")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma001_C_002")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma001_C_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma001_C_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma001_C_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma001_C_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma001_C_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma001_C_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma001_C_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma001_C_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma001_C_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma001_C_mines_003")
+--     _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma001_C_Idle")
+--     Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_C_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_C_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_C_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_001_C_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--   end
+-- end
 function s040_area4.OnEnter_Gamma_001_Dead()
   if Scenario.ReadFromBlackboard("Arena_Gamma_001_AllDead", false) then
     Game.SetSubAreaCurrentSetup("collision_camera_005", "PostGamma_001", true)
@@ -217,15 +219,15 @@ function s040_area4.OnEnter_Gamma_001_Dead()
     end
   end
 end
-function s040_area4.DelayedWarp()
-  Game.SetPlayerInputEnabled(false, true)
-  Game.FadeIn(2.5)
-  Game.GetPlayer().vPos = InitialPosition
-  Game.AddSF(1.5, "s040_area4.DelayedInput", "")
-end
-function s040_area4.DelayedInput()
-  Game.SetPlayerInputEnabled(true, true)
-end
+-- function s040_area4.DelayedWarp()
+--   Game.SetPlayerInputEnabled(false, true)
+--   Game.FadeIn(2.5)
+--   Game.GetPlayer().vPos = InitialPosition
+--   Game.AddSF(1.5, "s040_area4.DelayedInput", "")
+-- end
+-- function s040_area4.DelayedInput()
+--   Game.SetPlayerInputEnabled(true, true)
+-- end
 s040_area4.tDNAScanLandmarks = {
   SG_Alpha_001 = {
     "LM_ADNScanner_Samus_Alpha_001_001",

--- a/src/open_samus_returns_rando/files/levels/s040_area4.lua
+++ b/src/open_samus_returns_rando/files/levels/s040_area4.lua
@@ -47,7 +47,7 @@ function s040_area4.OnEnter_SetCheckpoint_Gamma_001()
   Game.SetBossCheckPointNames("ST_SG_Gamma_001", "ST_SG_Gamma_001", "SG_Gamma_001_A", "", "")
 end
 function s040_area4.OnGamma_001_A_Trigger()
-  if Game.GetEntity("SG_Gamma_001_A") ~= nil then
+  if Game.GetEntity("SG_Gamma_001_A") ~= nil and Scenario.ReadFromBlackboard("entity_TG_Gamma_001_A_enabled", true)  then
     Game.GetEntity("SG_Gamma_001_A").SPAWNGROUP:EnableSpawnGroup()
   end
 end

--- a/src/open_samus_returns_rando/files/levels/s040_area4.lua
+++ b/src/open_samus_returns_rando/files/levels/s040_area4.lua
@@ -219,15 +219,6 @@ function s040_area4.OnEnter_Gamma_001_Dead()
     end
   end
 end
--- function s040_area4.DelayedWarp()
---   Game.SetPlayerInputEnabled(false, true)
---   Game.FadeIn(2.5)
---   Game.GetPlayer().vPos = InitialPosition
---   Game.AddSF(1.5, "s040_area4.DelayedInput", "")
--- end
--- function s040_area4.DelayedInput()
---   Game.SetPlayerInputEnabled(true, true)
--- end
 s040_area4.tDNAScanLandmarks = {
   SG_Alpha_001 = {
     "LM_ADNScanner_Samus_Alpha_001_001",

--- a/src/open_samus_returns_rando/files/levels/s050_area5.lua
+++ b/src/open_samus_returns_rando/files/levels/s050_area5.lua
@@ -118,7 +118,7 @@ function s050_area5.OnEnter_SetCheckpoint_Gamma_002()
   Game.SetBossCheckPointNames("ST_SG_Gamma_002", "ST_SG_Gamma_002", "SG_Gamma_002_A", "", "")
 end
 function s050_area5.OnGamma_002_A_Trigger()
-  if Game.GetEntity("SG_Gamma_002_A") ~= nil then
+  if Game.GetEntity("SG_Gamma_002_A") ~= nil and Scenario.ReadFromBlackboard("entity_TG_Gamma_002_A_enabled", true) then
     Game.GetEntity("SG_Gamma_002_A").SPAWNGROUP:EnableSpawnGroup()
   end
 end

--- a/src/open_samus_returns_rando/files/levels/s050_area5.lua
+++ b/src/open_samus_returns_rando/files/levels/s050_area5.lua
@@ -115,19 +115,21 @@ function s050_area5.OnEnter_ActivationTeleport_05_01()
   Game.OnTeleportApproached("LE_Teleporter_05_01")
 end
 function s050_area5.OnEnter_SetCheckpoint_Gamma_002()
-  Game.SetBossCheckPointNames("ST_SG_Gamma_002", "ST_SG_Gamma_002", "SG_Gamma_002_A", "SG_Gamma_002_B", "SG_Gamma_002_C")
+  Game.SetBossCheckPointNames("ST_SG_Gamma_002", "ST_SG_Gamma_002", "SG_Gamma_002_A", "", "")
 end
 function s050_area5.OnGamma_002_A_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_002", "A")
+  if Game.GetEntity("SG_Gamma_002_A") ~= nil then
+    Game.GetEntity("SG_Gamma_002_A").SPAWNGROUP:EnableSpawnGroup()
+  end
 end
 function s050_area5.OnGamma_002_Intro_A_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_002_Intro_A") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_002_Intro_A").ANIMATION:SetAction("spawn")
-  end
+  -- if Game.GetEntity("LE_Valve_Gamma_002_Intro_A") ~= nil then
+  --   Game.GetEntity("LE_Valve_Gamma_002_Intro_A").ANIMATION:SetAction("spawn")
+  -- end
   s050_area5.OnGamma_002_A_Generated(_ARG_0_, _ARG_1_)
 end
 function s050_area5.OnGamma_002_A_Generated(_ARG_0_, _ARG_1_)
-  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_002_A", true)
+  Scenario.SetMetroidSpawngroupOnCurrentScenario(_ARG_0_, "SG_Gamma_002_A")
   if _ARG_1_ ~= nil then
     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door014")
     _ARG_1_.AI.bPlaceholder = false
@@ -169,107 +171,107 @@ function s050_area5.OnGamma_002_A_Generated(_ARG_0_, _ARG_1_)
     -- end
   end
 end
-function s050_area5.OnGamma_002_B_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_002", "B")
-end
-function s050_area5.OnGamma_002_Intro_B_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_002_Intro_B") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_002_Intro_B").ANIMATION:SetAction("spawn")
-  end
-  s050_area5.OnGamma_002_B_Generated(_ARG_0_, _ARG_1_)
-end
-function s050_area5.OnGamma_002_B_Generated(_ARG_0_, _ARG_1_)
-  if _ARG_1_ ~= nil then
-    -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door014")
-    _ARG_1_.AI.bPlaceholder = false
-    _ARG_1_.AI:AddBossCamera("CAM_Gamma")
-    _ARG_1_.AI:AddBossCameraFloorLandmark("LM_Gamma_002_B")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma002_B_001")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma002_B_002")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma002_B_003")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma002_B_001")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma002_B_002")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma002_B_003")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma002_B_001")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma002_B_002")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma002_B_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma002_B_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma002_B_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma002_B_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma002_B_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma002_B_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma002_B_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma002_B_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma002_B_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma002_B_mines_003")
-    _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma002_B_Idle_001")
-    Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
-    if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_B_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_B_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-    if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_B_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_B_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-  end
-end
-function s050_area5.OnGamma_002_C_Trigger()
-  Gamma.OnMultiArenaTrigger("Gamma_002", "C")
-end
-function s050_area5.OnGamma_002_Intro_C_Generated(_ARG_0_, _ARG_1_)
-  if Game.GetEntity("LE_Valve_Gamma_002_Intro_C") ~= nil then
-    Game.GetEntity("LE_Valve_Gamma_002_Intro_C").ANIMATION:SetAction("spawn")
-  end
-  s050_area5.OnGamma_002_C_Generated(_ARG_0_, _ARG_1_)
-end
-function s050_area5.OnGamma_002_C_Generated(_ARG_0_, _ARG_1_)
-  if _ARG_1_ ~= nil then
-    -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door014")
-    _ARG_1_.AI.bPlaceholder = false
-    _ARG_1_.AI:AddBossCamera("CAM_Gamma")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma002_C_001")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma002_C_002")
-    _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma002_C_003")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma002_C_001")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma002_C_002")
-    _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma002_C_003")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma002_C_001")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma002_C_002")
-    _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma002_C_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma002_C_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma002_C_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma002_C_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma002_C_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma002_C_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma002_C_mines_003")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma002_C_mines_001")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma002_C_mines_002")
-    _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma002_C_mines_003")
-    _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma002_C_Idle_001")
-    Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
-    if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_C_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_C_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-    if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_C_001")
-      _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_C_002")
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
-      _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
-    end
-  end
-end
+-- function s050_area5.OnGamma_002_B_Trigger()
+--   Gamma.OnMultiArenaTrigger("Gamma_002", "B")
+-- end
+-- function s050_area5.OnGamma_002_Intro_B_Generated(_ARG_0_, _ARG_1_)
+--   if Game.GetEntity("LE_Valve_Gamma_002_Intro_B") ~= nil then
+--     Game.GetEntity("LE_Valve_Gamma_002_Intro_B").ANIMATION:SetAction("spawn")
+--   end
+--   s050_area5.OnGamma_002_B_Generated(_ARG_0_, _ARG_1_)
+-- end
+-- function s050_area5.OnGamma_002_B_Generated(_ARG_0_, _ARG_1_)
+--   if _ARG_1_ ~= nil then
+--     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door014")
+--     _ARG_1_.AI.bPlaceholder = false
+--     _ARG_1_.AI:AddBossCamera("CAM_Gamma")
+--     _ARG_1_.AI:AddBossCameraFloorLandmark("LM_Gamma_002_B")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma002_B_001")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma002_B_002")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma002_B_003")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma002_B_001")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma002_B_002")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma002_B_003")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma002_B_001")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma002_B_002")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma002_B_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma002_B_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma002_B_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma002_B_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma002_B_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma002_B_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma002_B_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma002_B_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma002_B_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma002_B_mines_003")
+--     _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma002_B_Idle_001")
+--     Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_B_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_B_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_B_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_B_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--   end
+-- end
+-- function s050_area5.OnGamma_002_C_Trigger()
+--   Gamma.OnMultiArenaTrigger("Gamma_002", "C")
+-- end
+-- function s050_area5.OnGamma_002_Intro_C_Generated(_ARG_0_, _ARG_1_)
+--   if Game.GetEntity("LE_Valve_Gamma_002_Intro_C") ~= nil then
+--     Game.GetEntity("LE_Valve_Gamma_002_Intro_C").ANIMATION:SetAction("spawn")
+--   end
+--   s050_area5.OnGamma_002_C_Generated(_ARG_0_, _ARG_1_)
+-- end
+-- function s050_area5.OnGamma_002_C_Generated(_ARG_0_, _ARG_1_)
+--   if _ARG_1_ ~= nil then
+--     -- _ARG_1_.AI:AddBossDoorUnlockedOnDeath("Door014")
+--     _ARG_1_.AI.bPlaceholder = false
+--     _ARG_1_.AI:AddBossCamera("CAM_Gamma")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma002_C_001")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma002_C_002")
+--     _ARG_1_.AI:AddPresetLogicPath(0, "PATH_Gamma002_C_003")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma002_C_001")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma002_C_002")
+--     _ARG_1_.AI:AddPresetLogicPath(1, "PATH_Gamma002_C_003")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma002_C_001")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma002_C_002")
+--     _ARG_1_.AI:AddPresetLogicPath(2, "PATH_Gamma002_C_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma002_C_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma002_C_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(0, "PATH_Gamma002_C_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma002_C_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma002_C_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(1, "PATH_Gamma002_C_mines_003")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma002_C_mines_001")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma002_C_mines_002")
+--     _ARG_1_.AI:AddElectricMinesLogicPath(2, "PATH_Gamma002_C_mines_003")
+--     _ARG_1_.AI:AddIdleLogicPath("PATH_Gamma002_C_Idle_001")
+--     Gamma.SetArenaLife(_ARG_0_, _ARG_1_)
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 0 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_C_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_C_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.6)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 60)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--     if Gamma.GetNumValveUsed(_ARG_0_) == 1 then
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_C_001")
+--       _ARG_1_.AI:AddValve("LE_Valve_Gamma_002_C_002")
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveLifePct", 0.3)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveTime", 90)
+--       _ARG_1_.AI:AddBlackboardParam("fGotoValveSamusLife", 99)
+--     end
+--   end
+-- end
 function s050_area5.OnEnter_Gamma_002_Dead()
   if Scenario.ReadFromBlackboard("Arena_Gamma_002_AllDead", false) then
     Game.SetSubAreaCurrentSetup("collision_camera_009", "PostGamma_002", true)

--- a/src/open_samus_returns_rando/files/templates/metroid_template.lua
+++ b/src/open_samus_returns_rando/files/templates/metroid_template.lua
@@ -13,7 +13,7 @@ function Metroid.DisableSpawnGroup(spawnGroupName)
 end
 
 function Metroid.DelayedDelete(spawnGroupName)
-    Game.DeleteEntity(spawnGroupName)
+    Game.DisableEntity(spawnGroupName)
     if spawnGroupName == "SG_Gamma_001_A" then
         InitialPosition = Game.GetPlayer().vPos
         Game.GetPlayer().vPos = Game.GetEntity("ST_SG_Gamma_001").vPos
@@ -50,6 +50,10 @@ function Metroid.RemoveMetroid(_ARG_0_)
             Game.AddSF(4.0, "Metroid.DelayedDelete", "s", spawnGroupName)
         -- disable single arena metroid
         else
+            -- TODO: This should not be hard coded (and is also wrong for all metroids except 007)
+            local allDead = "Arena_" .. string.sub(spawnGroupName, 4, -3) .. "_AllDead"
+            Game.DisableTrigger("TG_Gamma_007_A")
+            Scenario.WriteToBlackboard(allDead, "b", true)
             Metroid.DisableSpawnGroup(spawnGroupName)
         end
 

--- a/src/open_samus_returns_rando/files/templates/metroid_template.lua
+++ b/src/open_samus_returns_rando/files/templates/metroid_template.lua
@@ -10,7 +10,7 @@ function Metroid.RemoveMetroid(_ARG_0_)
             local allDead = "Arena_" .. string.sub(spawnGroupName, 4, -3) .. "_AllDead"
             local gamma = string.sub(spawnGroupName, 10, 14)
             if spawnGroupName == "SG_Gamma_" .. gamma then
-                Game.DisableTrigger("TG_Gamma_" .. gamma)
+                Scenario.WriteToBlackboard("entity_" .. "TG_Gamma_" .. gamma .."_enabled", "b", false)
             end
             Scenario.WriteToBlackboard(allDead, "b", true)
         end
@@ -35,14 +35,11 @@ function Metroid.RemoveMetroid(_ARG_0_)
             Metroid.Pickups[scenario][spawnGroupName].OnPickedUp()
         end
         Game.SetInGameMusicState("RELAX")
-        -- FIXME: reloading from checkpoint respawns the gamma so ignore
-        if #spawnGroupName ~= 14 then
-            Game.SaveGame("checkpoint", "AfterNewAbilityAcquired", "", true)
-        end
         if scenario == "s000_surface" then
             Game.DisableEntity("TG_Intro_Alpha")
             Scenario.WriteToBlackboard("alpha_killed", "b", true)
         end
+        Game.SaveGame("checkpoint", "AfterNewAbilityAcquired", "", true)
     else
         GUI.LaunchMessage("Oops 2", "Metroid.Dummy", "")
     end

--- a/src/open_samus_returns_rando/files/templates/metroid_template.lua
+++ b/src/open_samus_returns_rando/files/templates/metroid_template.lua
@@ -47,7 +47,6 @@ function Metroid.RemoveMetroid(_ARG_0_)
         GUI.LaunchMessage("Oops 2", "Metroid.Dummy", "")
     end
     CurrentScenario.currentMetroidSpawngroup = nil
-    CurrentScenario.isMultiGamma = nil
 end
 
 Metroid.Pickups = TEMPLATE("mapping")

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -63,7 +63,7 @@ def patch_multi_room_gammas(editor: PatcherEditor):
         scenario.raw["actors"][4][spawnpoint]["components"][0]["arguments"][11]["value"] = True
         # make the trigger active
         scenario.raw["actors"][0][trigger]["components"][0]["arguments"][0]["value"] = True
-        # move Gamma_002_A so it doesn't just poof into existence when is spawns in
+        # move Gamma_002_A so it doesn't just poof into existence when it spawns
         if scenario_name == "s050_area5":
             scenario.raw["actors"][4]["Gamma_002_A"]["position"][0] = 17100.0
 

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -52,7 +52,7 @@ def patch_multi_room_gammas(editor: PatcherEditor):
         ("s033_area3b", "SG_Gamma_004_B", "Gamma_004_Intro_B", "TG_Gamma_004_B"),
         ("s036_area3c", "SG_Gamma_007_A", "SP_Gamma_007_Intro_A", "TG_Gamma_007_A"),
         ("s040_area4", "SG_Gamma_001_A", "SP_Gamma_001_Intro_A", "TG_Gamma_001_A"),
-        ("s050_area5", "SG_Gamma_002_A", "Gamma_002_Intro_A", "TG_Gamma_002_A"),
+        ("s050_area5", "SG_Gamma_002_A", "Gamma_002_A", "TG_Gamma_002_A"),
     ]
 
     for scenario_name, spawngroup, spawnpoint, trigger in gamma_actors:
@@ -63,6 +63,9 @@ def patch_multi_room_gammas(editor: PatcherEditor):
         scenario.raw["actors"][4][spawnpoint]["components"][0]["arguments"][11]["value"] = True
         # make the trigger active
         scenario.raw["actors"][0][trigger]["components"][0]["arguments"][0]["value"] = True
+        # move Gamma_002_A so it doesn't just poof into existence when is spawns in
+        if scenario_name == "s050_area5":
+            scenario.raw["actors"][4]["Gamma_002_A"]["position"][0] = 17100.0
 
 
 def patch_pickup_rotation(editor: PatcherEditor):

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -19,6 +19,7 @@ MULTI_ROOM_GAMMAS = [
     {"scenario": "s033_area3b", "layer": 3, "actor": "SG_Gamma_004_C"},
     {"scenario": "s033_area3b", "layer": 4, "actor": "Gamma_004_C"},
     {"scenario": "s033_area3b", "layer": 4, "actor": "Gamma_004_Intro_C"},
+    {"scenario": "s036_area3c", "layer": 0, "actor": "TG_Gamma_006_Dead_003"},
     {"scenario": "s036_area3c", "layer": 0, "actor": "TG_Gamma_007_B"},
     {"scenario": "s036_area3c", "layer": 3, "actor": "SG_Gamma_007_B"},
     {"scenario": "s036_area3c", "layer": 4, "actor": "SP_Gamma_007_B"},

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -3,24 +3,40 @@ from mercury_engine_data_structures.formats import Bmsad, Bmsbk, Bmtun
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 MULTI_ROOM_GAMMAS = [
+    {"scenario": "s030_area3", "layer": 0, "actor": "TG_Gamma_005_A"},
+    {"scenario": "s030_area3", "layer": 3, "actor": "SG_Gamma_005_A"},
     {"scenario": "s030_area3", "layer": 4, "actor": "SP_Gamma_005_A"},
     {"scenario": "s030_area3", "layer": 4, "actor": "SP_Gamma_005_Intro_A"},
+    {"scenario": "s030_area3", "layer": 0, "actor": "TG_Gamma_005_B"},
+    {"scenario": "s030_area3", "layer": 3, "actor": "SG_Gamma_005_B"},
     {"scenario": "s030_area3", "layer": 4, "actor": "SP_Gamma_005_B"},
     {"scenario": "s030_area3", "layer": 4, "actor": "SP_Gamma_005_Intro_B"},
+    {"scenario": "s033_area3b", "layer": 0, "actor": "TG_Gamma_004_A"},
+    {"scenario": "s033_area3b", "layer": 3, "actor": "SG_Gamma_004_A"},
     {"scenario": "s033_area3b", "layer": 4, "actor": "Gamma_004_A"},
     {"scenario": "s033_area3b", "layer": 4, "actor": "Gamma_004_Intro_A"},
+    {"scenario": "s033_area3b", "layer": 0, "actor": "TG_Gamma_004_C"},
+    {"scenario": "s033_area3b", "layer": 3, "actor": "SG_Gamma_004_C"},
     {"scenario": "s033_area3b", "layer": 4, "actor": "Gamma_004_C"},
     {"scenario": "s033_area3b", "layer": 4, "actor": "Gamma_004_Intro_C"},
+    {"scenario": "s036_area3c", "layer": 0, "actor": "TG_Gamma_007_B"},
+    {"scenario": "s036_area3c", "layer": 3, "actor": "SG_Gamma_007_B"},
     {"scenario": "s036_area3c", "layer": 4, "actor": "SP_Gamma_007_B"},
     {"scenario": "s036_area3c", "layer": 4, "actor": "SP_Gamma_007_Intro_B"},
-    {"scenario": "s036_area3c", "layer": 3, "actor": "SG_Gamma_007_B"},
-    {"scenario": "s036_area3c", "layer": 0, "actor": "TG_Gamma_007_B"},
+    {"scenario": "s040_area4", "layer": 0, "actor": "TG_Gamma_001_B"},
+    {"scenario": "s040_area4", "layer": 3, "actor": "SG_Gamma_001_B"},
     {"scenario": "s040_area4", "layer": 4, "actor": "SP_Gamma_001_B"},
     {"scenario": "s040_area4", "layer": 4, "actor": "SP_Gamma_001_Intro_B"},
+    {"scenario": "s040_area4", "layer": 0, "actor": "TG_Gamma_001_C"},
+    {"scenario": "s040_area4", "layer": 3, "actor": "SG_Gamma_001_C"},
     {"scenario": "s040_area4", "layer": 4, "actor": "SP_Gamma_001_C"},
     {"scenario": "s040_area4", "layer": 4, "actor": "SP_Gamma_001_Intro_C"},
+    {"scenario": "s050_area5", "layer": 0, "actor": "TG_Gamma_002_B"},
+    {"scenario": "s050_area5", "layer": 3, "actor": "SG_Gamma_002_B"},
     {"scenario": "s050_area5", "layer": 4, "actor": "Gamma_002_B"},
     {"scenario": "s050_area5", "layer": 4, "actor": "Gamma_002_Intro_B"},
+    {"scenario": "s050_area5", "layer": 0, "actor": "TG_Gamma_002_C"},
+    {"scenario": "s050_area5", "layer": 3, "actor": "SG_Gamma_002_C"},
     {"scenario": "s050_area5", "layer": 4, "actor": "Gamma_002_C"},
     {"scenario": "s050_area5", "layer": 4, "actor": "Gamma_002_Intro_C"},
 ]
@@ -29,6 +45,23 @@ MULTI_ROOM_GAMMAS = [
 def patch_multi_room_gammas(editor: PatcherEditor):
     for reference in MULTI_ROOM_GAMMAS:
         editor.remove_entity(reference)
+
+    gamma_actors = [
+        ("s030_area3", "SG_Gamma_005_C", "SP_Gamma_005_C", "TG_Gamma_005_C"),
+        ("s033_area3b", "SG_Gamma_004_B", "Gamma_004_Intro_B", "TG_Gamma_004_B"),
+        ("s036_area3c", "SG_Gamma_007_A", "SP_Gamma_007_Intro_A", "TG_Gamma_007_A"),
+        ("s040_area4", "SG_Gamma_001_A", "SP_Gamma_001_Intro_A", "TG_Gamma_001_A"),
+        ("s050_area5", "SG_Gamma_002_A", "Gamma_002_Intro_A", "TG_Gamma_002_A"),
+    ]
+
+    for scenario_name, spawngroup, spawnpoint, trigger in gamma_actors:
+        scenario = editor.get_scenario(scenario_name)
+        # remove the gamma name ¯\_(ツ)_/¯
+        scenario.raw["actors"][3][spawngroup]["components"][0]["arguments"][27]["value"] = ""
+        # ¯\_(ツ)_/¯
+        scenario.raw["actors"][4][spawnpoint]["components"][0]["arguments"][11]["value"] = True
+        # make the trigger active
+        scenario.raw["actors"][0][trigger]["components"][0]["arguments"][0]["value"] = True
 
 
 def patch_pickup_rotation(editor: PatcherEditor):
@@ -199,10 +232,3 @@ def apply_static_fixes(editor: PatcherEditor):
     nerf_ridley_fight(editor)
     increase_pb_drop_chance(editor)
     fix_area2b_hp_item_001_deletion(editor)
-    scenario = editor.get_scenario("s036_area3c")
-    # remove the gamma name ¯\_(ツ)_/¯
-    scenario.raw["actors"][3]["SG_Gamma_007_A"]["components"][0]["arguments"][27]["value"] = ""
-    # ¯\_(ツ)_/¯
-    scenario.raw["actors"][4]["SP_Gamma_007_Intro_A"]["components"][0]["arguments"][11]["value"] = True
-    # make the trigger active
-    scenario.raw["actors"][0]["TG_Gamma_007_A"]["components"][0]["arguments"][0]["value"] = True

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -13,6 +13,8 @@ MULTI_ROOM_GAMMAS = [
     {"scenario": "s033_area3b", "layer": 4, "actor": "Gamma_004_Intro_C"},
     {"scenario": "s036_area3c", "layer": 4, "actor": "SP_Gamma_007_B"},
     {"scenario": "s036_area3c", "layer": 4, "actor": "SP_Gamma_007_Intro_B"},
+    {"scenario": "s036_area3c", "layer": 3, "actor": "SG_Gamma_007_B"},
+    {"scenario": "s036_area3c", "layer": 0, "actor": "TG_Gamma_007_B"},
     {"scenario": "s040_area4", "layer": 4, "actor": "SP_Gamma_001_B"},
     {"scenario": "s040_area4", "layer": 4, "actor": "SP_Gamma_001_Intro_B"},
     {"scenario": "s040_area4", "layer": 4, "actor": "SP_Gamma_001_C"},
@@ -197,3 +199,10 @@ def apply_static_fixes(editor: PatcherEditor):
     nerf_ridley_fight(editor)
     increase_pb_drop_chance(editor)
     fix_area2b_hp_item_001_deletion(editor)
+    scenario = editor.get_scenario("s036_area3c")
+    # remove the gamma name ¯\_(ツ)_/¯
+    scenario.raw["actors"][3]["SG_Gamma_007_A"]["components"][0]["arguments"][27]["value"] = ""
+    # ¯\_(ツ)_/¯
+    scenario.raw["actors"][4]["SP_Gamma_007_Intro_A"]["components"][0]["arguments"][11]["value"] = True
+    # make the trigger active
+    scenario.raw["actors"][0]["TG_Gamma_007_A"]["components"][0]["arguments"][0]["value"] = True

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -1,27 +1,12 @@
 {
     "$schema": "../../src/open_samus_returns_rando/files/schema.json",
     "starting_location": {
-        "scenario": "s036_area3c",
-        "actor": "ST_SaveStation"
+        "scenario": "s000_surface",
+        "actor": "StartPoint0"
     },
     "starting_items": {
-        "ITEM_VARIA_SUIT": 1,
-        "ITEM_GRAVITY_SUIT": 1,
-        "ITEM_MORPH_BALL": 1,
-        "ITEM_HIGH_JUMP_BOOTS": 1,
-        "ITEM_SPACE_JUMP": 1,
-        "ITEM_SPIDER_BALL": 1,
-        "ITEM_WEAPON_CHARGE_BEAM": 1,
-        "ITEM_WEAPON_BOMB": 1,
-        "ITEM_WEAPON_SUPER_MISSILE": 1,
-        "ITEM_WEAPON_POWER_BOMB": 1,
-        "ITEM_WEAPON_POWER_BOMB_MAX": 20,
-        "ITEM_SUPER_MISSILE_TANKS": 50,
-        "ITEM_WEAPON_SPAZER_BEAM": 1,
-        "ITEM_WEAPON_WAVE_BEAM": 1,
-        "ITEM_WEAPON_PLASMA_BEAM": 1,
         "ITEM_WEAPON_MISSILE_LAUNCHER": 1,
-        "ITEM_MISSILE_TANKS": 50,
+        "ITEM_MISSILE_TANKS": 24,
         "ITEM_SPECIAL_ENERGY_SCANNING_PULSE": 1,
         "ITEM_RANDO_DNA_11": 1,
         "ITEM_RANDO_DNA_12": 1,
@@ -52,7 +37,7 @@
         "ITEM_RANDO_DNA_37": 1,
         "ITEM_RANDO_DNA_38": 1,
         "ITEM_RANDO_DNA_39": 1,
-        "ITEM_MAX_LIFE": 999,
+        "ITEM_MAX_LIFE": 99,
         "ITEM_MAX_SPECIAL_ENERGY": 1000
     },
     "starting_text": [],

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -1,12 +1,27 @@
 {
     "$schema": "../../src/open_samus_returns_rando/files/schema.json",
     "starting_location": {
-        "scenario": "s000_surface",
-        "actor": "StartPoint0"
+        "scenario": "s036_area3c",
+        "actor": "ST_SaveStation"
     },
     "starting_items": {
+        "ITEM_VARIA_SUIT": 1,
+        "ITEM_GRAVITY_SUIT": 1,
+        "ITEM_MORPH_BALL": 1,
+        "ITEM_HIGH_JUMP_BOOTS": 1,
+        "ITEM_SPACE_JUMP": 1,
+        "ITEM_SPIDER_BALL": 1,
+        "ITEM_WEAPON_CHARGE_BEAM": 1,
+        "ITEM_WEAPON_BOMB": 1,
+        "ITEM_WEAPON_SUPER_MISSILE": 1,
+        "ITEM_WEAPON_POWER_BOMB": 1,
+        "ITEM_WEAPON_POWER_BOMB_MAX": 20,
+        "ITEM_SUPER_MISSILE_TANKS": 50,
+        "ITEM_WEAPON_SPAZER_BEAM": 1,
+        "ITEM_WEAPON_WAVE_BEAM": 1,
+        "ITEM_WEAPON_PLASMA_BEAM": 1,
         "ITEM_WEAPON_MISSILE_LAUNCHER": 1,
-        "ITEM_MISSILE_TANKS": 24,
+        "ITEM_MISSILE_TANKS": 50,
         "ITEM_SPECIAL_ENERGY_SCANNING_PULSE": 1,
         "ITEM_RANDO_DNA_11": 1,
         "ITEM_RANDO_DNA_12": 1,
@@ -37,7 +52,7 @@
         "ITEM_RANDO_DNA_37": 1,
         "ITEM_RANDO_DNA_38": 1,
         "ITEM_RANDO_DNA_39": 1,
-        "ITEM_MAX_LIFE": 99,
+        "ITEM_MAX_LIFE": 999,
         "ITEM_MAX_SPECIAL_ENERGY": 1000
     },
     "starting_text": [],


### PR DESCRIPTION
Reverts https://github.com/randovania/open-samus-returns-rando/pull/287

Makes a change to the SG and SP such that disabling the SG is enough to deactivate the radar.
Activates the TG for the Intro of 007 by default.
Needs to deactivate the trigger as part of the callback to not let the metroid respawn while the metroid setup is still active.

Does this the whole stuff work for 3DS?  Also regarding the whole crash when going to the right of teleporter room? If so, we can work with it further to rework all other multi gammas and get rid of the stupid warping stuff.
Also be aware that disabling the Trigger is just hard coded now...so killing 006 first will deactivate 007.