### PR TITLE
Ensure asset dependencies are added to the correct pkgs

### DIFF
--- a/src/open_samus_returns_rando/patcher_editor.py
+++ b/src/open_samus_returns_rando/patcher_editor.py
@@ -7,7 +7,7 @@ from mercury_engine_data_structures.file_tree_editor import FileTreeEditor
 from mercury_engine_data_structures.formats import BaseResource, Bmsld
 from mercury_engine_data_structures.game_check import Game
 
-from open_samus_returns_rando.constants import ALL_SCENARIOS
+from open_samus_returns_rando.constants import ALL_SCENARIOS, get_package_name
 
 T = typing.TypeVar("T")
 
@@ -39,7 +39,7 @@ class PatcherEditor(FileTreeEditor):
 
     def ensure_present_in_scenario(self, scenario: str, asset):
         for pkg in self.get_level_pkgs(scenario):
-            self.ensure_present(pkg, asset)
+            self.ensure_present(get_package_name(pkg, asset), asset)
 
     def get_scenario(self, name: str) -> Bmsld:
         return self.get_file(path_for_level(name) + ".bmsld", Bmsld)

--- a/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
@@ -2,7 +2,6 @@ import typing
 
 from construct import Container, ListContainer
 from mercury_engine_data_structures.formats import Bmsad, Bmsmsd
-from open_samus_returns_rando.constants import get_package_name
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 SCRIPT_COMPONENT = Container({
@@ -166,9 +165,8 @@ def update_item_seals(editor:PatcherEditor):
             scenario.raw.actors[16][seal]["type"] = "chozoseal"
 
         # Dependencies
-        for level_pkg in editor.get_level_pkgs(scenario_name):
-            for asset in editor.get_asset_names_in_folder("actors/props/chozoseal"):
-                editor.ensure_present(get_package_name(level_pkg, asset), asset)
+        for asset in editor.get_asset_names_in_folder("actors/props/chozoseal"):
+            editor.ensure_present_in_scenario(scenario_name, asset)
 
 
 def patch_chozo_seals(editor: PatcherEditor):

--- a/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
@@ -166,7 +166,7 @@ def update_item_seals(editor:PatcherEditor):
             scenario.raw.actors[16][seal]["type"] = "chozoseal"
 
         # Dependencies
-        for level_pkg in editor.get_all_level_pkgs():
+        for level_pkg in editor.get_level_pkgs(scenario_name):
             for asset in editor.get_asset_names_in_folder("actors/props/chozoseal"):
                 editor.ensure_present(get_package_name(level_pkg, asset), asset)
 

--- a/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
@@ -105,10 +105,9 @@ new_seals = [
         "s100_area10", [-4100.0, 11200.0, 0.0], [-4100.0, 11200.0, 0.0], 253,
         ["collision_camera_022", "collision_camera_024"]
     ),
-    # Currently breaks Ridley if added :(
-    # NewChozoSeal(
-    #     "s110_surfaceb", [-28150.0, 300.0, 0.0], [-28150.0, 300.0, 0.0], 145, ["collision_camera_017"]
-    # ),
+    NewChozoSeal(
+        "s110_surfaceb", [-28150.0, 300.0, 0.0], [-28150.0, 300.0, 0.0], 145, ["collision_camera_017"]
+    ),
 ]
 
 def add_chozo_seals(editor: PatcherEditor, new_seal: NewChozoSeal):

--- a/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
@@ -2,6 +2,7 @@ import typing
 
 from construct import Container, ListContainer
 from mercury_engine_data_structures.formats import Bmsad, Bmsmsd
+from open_samus_returns_rando.constants import get_package_name
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 SCRIPT_COMPONENT = Container({
@@ -165,8 +166,9 @@ def update_item_seals(editor:PatcherEditor):
             scenario.raw.actors[16][seal]["type"] = "chozoseal"
 
         # Dependencies
-        for asset in editor.get_asset_names_in_folder("actors/props/chozoseal"):
-            editor.ensure_present_in_scenario(scenario_name, asset)
+        for level_pkg in editor.get_all_level_pkgs():
+            for asset in editor.get_asset_names_in_folder("actors/props/chozoseal"):
+                editor.ensure_present(get_package_name(level_pkg, asset), asset)
 
 
 def patch_chozo_seals(editor: PatcherEditor):


### PR DESCRIPTION
Just like with shuffled pickups, we have to ensure the new Chozo Seal assets are added to the correct pkgs, otherwise Diggernaut breaks and the fight doesn't end.