### PR TITLE
Fix reserve tanks as starting items

### DIFF
--- a/src/open_samus_returns_rando/files/templates/custom_init.lua
+++ b/src/open_samus_returns_rando/files/templates/custom_init.lua
@@ -23,8 +23,9 @@ function Init.InitGameBlackboard()
       local current_amount = Blackboard.GetProp("PLAYER_INVENTORY", "ITEM_ADN") or 0
       Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_ADN", "f", current_amount + 1)
     end
-    if string.sub(_FORV_3_, 1, 17) == "ITEM_RESERVE_TANK" then
-      if _FORV_3_ ~= "ITEM_RESERVE_TANK_MISSILE" or Blackboard.GetProp("PLAYER_INVENTORY", "ITEM_WEAPON_MISSILE_LAUNCHER") then
+    if string.sub(_FORV_3_, 1, 17) == "ITEM_RESERVE_TANK" and _FORV_4_ > 0 then
+      local missile_launcher = Init.tNewGameInventory["ITEM_WEAPON_MISSILE_LAUNCHER"]
+      if _FORV_3_ ~= "ITEM_RESERVE_TANK_MISSILE" or (missile_launcher ~= nil and missile_launcher > 0) then
         Blackboard.SetProp("GAME", _FORV_3_ .. "_ACTIVE", "b", true)
         Blackboard.SetProp("GAME", _FORV_3_ .. "_FULL", "b", true)
       end
@@ -71,6 +72,7 @@ function Init.InitNewGame(arg1, arg2, arg3, arg4, arg4)
     if Init.bRevealMap then
       Game.AddGUISF(0.0, Game.ScanVisitDiscoverEverything, "", "")
     end
+    Game.SaveGame("savedata", "", Init.sStartingActor, true)
   end
 
 Game.SetForceSkipCutscenes(true)

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -211,6 +211,7 @@ class LuaEditor:
             max_life += etanks * energy_per_tank
 
         # use _MAX if main is unlocked to unlock the ammo too
+        # FIXME: These checks are kinda wrong if you use something like `"ITEM_WEAPON_MISSILE_LAUNCHER": 0`
         if "ITEM_WEAPON_MISSILE_LAUNCHER" in inventory and "ITEM_MISSILE_TANKS" in inventory:
             inventory["ITEM_WEAPON_MISSILE_MAX"] = inventory.pop("ITEM_MISSILE_TANKS")
         if "ITEM_WEAPON_SUPER_MISSILE" in inventory and "ITEM_SUPER_MISSILE_TANKS" in inventory:


### PR DESCRIPTION
Fixes #310

- Immediately saves the game after load to persistently save reserve tanks as starting items.
- Checks Init.tNewGameInventory for missile launcher shenanigans instead of the blackboard because that is dependent on the order how the values are iterated.
- also checks if the reserve tanks have a value > 0 instead of just the  key being present (I often test by setting the amount to 0 but that didn't work with how the check was done)