### PR TITLE
Support Elevator Shuffle

### DIFF
--- a/src/open_samus_returns_rando/files/custom/scenario.lua
+++ b/src/open_samus_returns_rando/files/custom/scenario.lua
@@ -3,6 +3,7 @@ Game.ImportLibrary("system/scripts/guilib.lua", false)
 Game.ImportLibrary("system/scripts/cosmetics.lua", false)
 
 Game.DoFile("system/scripts/room_names.lua")
+Game.DoFile("system/scripts/elevators.lua")
 
 Scenario = Scenario or {}
 setmetatable(Scenario, {__index = _G})
@@ -142,4 +143,14 @@ end
 
 function Scenario.UpdateRoomName(new_subarea)
   Game.AddSF(0.0, "RoomNameGui.Update", "s", new_subarea)
+end
+
+function Scenario.RandoOnElevatorUse(from_actor, _ARG_1_, _ARG_2_)
+  local destination = ElevatorDestinations[Scenario.CurrentScenarioID][from_actor.sName]
+  if Scenario.CurrentScenario == destination.scenario then
+    Game.AddGUISF(0.5, GUI.ElevatorStartUseActionStep2InnerArea, "")
+  else
+    Game.AddGUISF(0.5, GUI.ElevatorStartUseActionStep2InterArea, "")
+  end
+  Elevator.Use("c10_samus", destination.scenario, destination.actor, _ARG_2_)
 end

--- a/src/open_samus_returns_rando/files/custom/scenario.lua
+++ b/src/open_samus_returns_rando/files/custom/scenario.lua
@@ -147,10 +147,6 @@ end
 
 function Scenario.RandoOnElevatorUse(from_actor, _ARG_1_, _ARG_2_)
   local destination = ElevatorDestinations[Scenario.CurrentScenarioID][from_actor.sName]
-  if Scenario.CurrentScenario == destination.scenario then
-    Game.AddGUISF(0.5, GUI.ElevatorStartUseActionStep2InnerArea, "")
-  else
-    Game.AddGUISF(0.5, GUI.ElevatorStartUseActionStep2InterArea, "")
-  end
+  Game.AddGUISF(0.5, GUI.ElevatorStartUseActionStep2InterArea, "")
   Elevator.Use("c10_samus", destination.scenario, destination.actor, _ARG_2_)
 end

--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -139,7 +139,8 @@
                         }
                     }
                 }
-            }
+            },
+            "default": {}
         },
         "door_patches": {
             "type": "array",

--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -114,21 +114,31 @@
             }
         },
         "elevators": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "teleporter": {
-                        "$ref": "#/$defs/actor_reference_with_layer"
-                    },
-                    "destination": {
-                        "$ref": "#/$defs/actor_reference"
+            "type": "object",
+            "description": "A dictionary of dictionaries mapping scenario and elevator actor to a connecting elevator",
+            "patternProperties": {
+                ".*": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "default": {},
+                    "patternProperties": {
+                        ".*": {
+                            "type": "object",
+                            "properties": {
+                                "scenario": {
+                                    "$ref": "#/$defs/scenario_name"
+                                },
+                                "actor": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "scenario",
+                                "actor"
+                            ]
+                        }
                     }
-                },
-                "required": [
-                    "teleporter",
-                    "destination"
-                ]
+                }
             }
         },
         "door_patches": {

--- a/src/open_samus_returns_rando/files/templates/elevators.lua
+++ b/src/open_samus_returns_rando/files/templates/elevators.lua
@@ -1,0 +1,1 @@
+ElevatorDestinations = TEMPLATE("elevator_dict")

--- a/src/open_samus_returns_rando/misc_patches/elevators.py
+++ b/src/open_samus_returns_rando/misc_patches/elevators.py
@@ -1,0 +1,97 @@
+from construct import Container
+from mercury_engine_data_structures.formats.lua import Lua
+from open_samus_returns_rando.misc_patches import lua_util
+from open_samus_returns_rando.patcher_editor import PatcherEditor
+
+
+def create_elevator_table(editor: PatcherEditor, configuration: dict):
+    py_dict: dict = configuration["elevators"]
+
+    file = lua_util.replace_lua_template("elevators.lua", {"elevator_dict": py_dict}, True)
+    editor.add_new_asset(
+        "system/scripts/elevators.lc",
+        Lua(Container(lua_text=file), editor.target_game),
+        []
+    )
+
+
+def update_elevators(editor: PatcherEditor, configuration: dict):
+    ELEVATORS = {
+        "s000_surface": ["LE_Platform_Elevator_FromArea01"],
+        "s010_area1": [
+            "LE_Platform_Elevator_FromArea00",
+            "LE_Platform_Elevator_FromArea02",
+        ],
+        "s020_area2": [
+            "LE_Platform_Elevator_FromArea02B",
+            "LE_Platform_Elevator_FromArea02C",
+        ],
+        "s025_area2b": ["LE_Platform_Elevator_FromArea02A"],
+        "s028_area2c": [
+            "LE_Platform_Elevator_FromArea01",
+            "LE_Platform_Elevator_FromArea02A",
+            "LE_Platform_Elevator_FromArea03",
+        ],
+        "s030_area3": [
+            "LE_Platform_Elevator_FromArea02",
+            "LE_Platform_Elevator_FromArea03B_01",
+            "LE_Platform_Elevator_FromArea03B_02",
+            "LE_Platform_Elevator_FromArea03C",
+            "LE_Platform_Elevator_FromArea04",
+        ],
+        "s033_area3b": [
+            "LE_Platform_Elevator_FromArea03A_01",
+            "LE_Platform_Elevator_FromArea03A_02",
+            "LE_Platform_Elevator_FromArea03C",
+        ],
+        "s036_area3c": [
+            "LE_Platform_Elevator_FromArea03A",
+            "LE_Platform_Elevator_FromArea03B",
+        ],
+        "s040_area4": [
+            "LE_Platform_Elevator_FromArea03",
+            "LE_Platform_Elevator_FromArea05",
+            "LE_Platform_Elevator_FromArea06",
+        ],
+        "s050_area5": ["LE_Platform_Elevator_FromArea04"],
+        "s060_area6": [
+            "LE_Platform_Elevator_FromArea04",
+            "LE_Platform_Elevator_FromArea06C_01",
+            "LE_Platform_Elevator_FromArea06C_02",
+            "LE_Platform_Elevator_FromArea07",
+        ],
+        "s065_area6b": [
+            "LE_Platform_Elevator_FromArea06C_01",
+            "LE_Platform_Elevator_FromArea06C_02",
+        ],
+        "s067_area6c": [
+            "LE_Platform_Elevator_FromArea06A_01",
+            "LE_Platform_Elevator_FromArea06A_02",
+            "LE_Platform_Elevator_FromArea06B_01",
+            "LE_Platform_Elevator_FromArea06B_02",
+        ],
+        "s070_area7": [
+            "LE_Platform_Elevator_FromArea06",
+            "LE_Platform_Elevator_FromArea09",
+        ],
+        "s090_area9": [
+            "LE_Platform_Elevator_FromArea07",
+            "LE_Platform_Elevator_FromArea10",
+        ],
+        "s100_area10": [
+            "LE_Platform_Elevator_FromArea09",
+            "LE_Platform_Elevator_FromAreaSurfaceB",
+        ],
+        "s110_surfaceb": ["LE_Platform_Elevator_FromArea10"],
+    }
+
+    for scenario_name, elevators in ELEVATORS.items():
+        scenario = editor.get_scenario(scenario_name)
+        for elevator in elevators:
+            platform = scenario.raw.actors[10][elevator]["components"][0]
+            platform["arguments"][1]["value"] = "Scenario.RandoOnElevatorUse"
+
+
+def patch_elevators(editor: PatcherEditor, configuration: dict):
+    create_elevator_table(editor, configuration)
+    update_elevators(editor, configuration)

--- a/src/open_samus_returns_rando/misc_patches/elevators.py
+++ b/src/open_samus_returns_rando/misc_patches/elevators.py
@@ -16,76 +16,7 @@ def create_elevator_table(editor: PatcherEditor, configuration: dict):
 
 
 def update_elevators(editor: PatcherEditor, configuration: dict):
-    ELEVATORS = {
-        "s000_surface": ["LE_Platform_Elevator_FromArea01"],
-        "s010_area1": [
-            "LE_Platform_Elevator_FromArea00",
-            "LE_Platform_Elevator_FromArea02",
-        ],
-        "s020_area2": [
-            "LE_Platform_Elevator_FromArea02B",
-            "LE_Platform_Elevator_FromArea02C",
-        ],
-        "s025_area2b": ["LE_Platform_Elevator_FromArea02A"],
-        "s028_area2c": [
-            "LE_Platform_Elevator_FromArea01",
-            "LE_Platform_Elevator_FromArea02A",
-            "LE_Platform_Elevator_FromArea03",
-        ],
-        "s030_area3": [
-            "LE_Platform_Elevator_FromArea02",
-            "LE_Platform_Elevator_FromArea03B_01",
-            "LE_Platform_Elevator_FromArea03B_02",
-            "LE_Platform_Elevator_FromArea03C",
-            "LE_Platform_Elevator_FromArea04",
-        ],
-        "s033_area3b": [
-            "LE_Platform_Elevator_FromArea03A_01",
-            "LE_Platform_Elevator_FromArea03A_02",
-            "LE_Platform_Elevator_FromArea03C",
-        ],
-        "s036_area3c": [
-            "LE_Platform_Elevator_FromArea03A",
-            "LE_Platform_Elevator_FromArea03B",
-        ],
-        "s040_area4": [
-            "LE_Platform_Elevator_FromArea03",
-            "LE_Platform_Elevator_FromArea05",
-            "LE_Platform_Elevator_FromArea06",
-        ],
-        "s050_area5": ["LE_Platform_Elevator_FromArea04"],
-        "s060_area6": [
-            "LE_Platform_Elevator_FromArea04",
-            "LE_Platform_Elevator_FromArea06C_01",
-            "LE_Platform_Elevator_FromArea06C_02",
-            "LE_Platform_Elevator_FromArea07",
-        ],
-        "s065_area6b": [
-            "LE_Platform_Elevator_FromArea06C_01",
-            "LE_Platform_Elevator_FromArea06C_02",
-        ],
-        "s067_area6c": [
-            "LE_Platform_Elevator_FromArea06A_01",
-            "LE_Platform_Elevator_FromArea06A_02",
-            "LE_Platform_Elevator_FromArea06B_01",
-            "LE_Platform_Elevator_FromArea06B_02",
-        ],
-        "s070_area7": [
-            "LE_Platform_Elevator_FromArea06",
-            "LE_Platform_Elevator_FromArea09",
-        ],
-        "s090_area9": [
-            "LE_Platform_Elevator_FromArea07",
-            "LE_Platform_Elevator_FromArea10",
-        ],
-        "s100_area10": [
-            "LE_Platform_Elevator_FromArea09",
-            "LE_Platform_Elevator_FromAreaSurfaceB",
-        ],
-        "s110_surfaceb": ["LE_Platform_Elevator_FromArea10"],
-    }
-
-    for scenario_name, elevators in ELEVATORS.items():
+    for scenario_name, elevators in configuration["elevators"].items():
         scenario = editor.get_scenario(scenario_name)
         for elevator in elevators:
             platform = scenario.raw.actors[10][elevator]["components"][0]

--- a/src/open_samus_returns_rando/samus_returns_patcher.py
+++ b/src/open_samus_returns_rando/samus_returns_patcher.py
@@ -11,6 +11,7 @@ from open_samus_returns_rando.logger import LOG
 from open_samus_returns_rando.lua_editor import LuaEditor
 from open_samus_returns_rando.misc_patches.collision_camera_table import create_collision_camera_table
 from open_samus_returns_rando.misc_patches.credits import patch_credits
+from open_samus_returns_rando.misc_patches.elevators import patch_elevators
 from open_samus_returns_rando.misc_patches.exefs import DSPatch
 from open_samus_returns_rando.misc_patches.spawn_points import patch_custom_spawn_points
 from open_samus_returns_rando.misc_patches.text_patches import add_spiderboost_status, apply_text_patches
@@ -115,6 +116,9 @@ def patch_extracted(input_path: Path, output_path: Path, configuration: dict):
 
      # Update cc_to_room_name.lua
     create_collision_camera_table(editor, configuration)
+
+    # Patch elevator destinations
+    patch_elevators(editor, configuration)
 
     out_romfs = output_path.joinpath("romfs")
     out_exefs = output_path.joinpath("exefs")

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -4022,6 +4022,20 @@
             }
         }
     ],
+    "elevators": {
+        "s010_area1": {
+            "LE_Platform_Elevator_FromArea02": {
+                "scenario": "s028_area2c",
+                "actor": "ST_FromArea01"
+            }
+        },
+        "s028_area2c": {
+            "LE_Platform_Elevator_FromArea01": {
+                "scenario": "s010_area1",
+                "actor": "ST_FromArea02"
+            }
+        }
+    },
     "energy_per_tank": 100,
     "reserves_per_tank": {
         "life_tank_size": 299,


### PR DESCRIPTION
Allows for the elevator destinations to be shuffled. Fixes #23 

TODO:

- [x] Add default elevator destinations so elevators not specified in a supplied JSON don't softlock the game when used
  - Either add to the schema or some other file