### PR TITLE
Refactors the custom Metroid checkpoints

### DIFF
--- a/src/open_samus_returns_rando/specific_patches/metroid_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/metroid_patches.py
@@ -127,10 +127,8 @@ def add_startpoints(editor: PatcherEditor, new_startpoint: NewStartPoint):
         scenario_file.raw.actors[5][new_startpoint.st_name]["rotation"][1] = new_startpoint.st_rotation
         if new_startpoint.st_out_name is not None:
             scenario_file.raw.actors[5][new_startpoint.st_out_name]["rotation"][1] = (
-            -abs(new_startpoint.st_rotation)
-            if new_startpoint.st_rotation == 90
-            else abs(new_startpoint.st_rotation)
-        )
+                -90 if new_startpoint.st_rotation == 90 else 90
+            )
     # Edge case where startpoint actors aren't being added but startpoint_out actors are
     if new_startpoint.st_out_name == "ST_SG_Omega_001_Out":
         scenario_file.raw.actors[5][new_startpoint.st_out_name]["rotation"][1] = new_startpoint.st_rotation

--- a/src/open_samus_returns_rando/specific_patches/metroid_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/metroid_patches.py
@@ -1,3 +1,4 @@
+import typing
 
 from construct import ListContainer
 from mercury_engine_data_structures.formats import Bmsad
@@ -53,259 +54,95 @@ def _patch_metroids(editor: PatcherEditor):
         script_component["functions"][0]["params"]["Param2"]["value"] = "Metroid"
 
 
-def _get_trigger(editor: PatcherEditor):
-    actor_to_copy = {
-        "scenario": "s025_area2b",
-        "layer": "0",
-        "actor": "TG_SetCheckpoint_001_Gamma_001",
-    }
-    checkpoint_trigger = editor.resolve_actor_reference(actor_to_copy)
-    return checkpoint_trigger
-
-
-def _get_spawnpoint(editor: PatcherEditor):
-    actor_to_copy = {
-        "scenario": "s025_area2b",
-        "layer": "5",
-        "actor": "ST_SG_Gamma_001",
-    }
-    spawnpoint = editor.resolve_actor_reference(actor_to_copy)
-    return spawnpoint
-
-
-def _create_checkpoint_alpha_surface(editor: PatcherEditor):
-    name_of_scenario = "s000_surface"
-    scenario_surface = editor.get_scenario(name_of_scenario)
-    name_of_trigger = "TG_SetCheckpoint_002_Alpha_001"
-    name_of_spawnpoint = "ST_SG_Alpha_001B"
-
-    trigger = _get_trigger(editor)
-    spawnpoint = _get_spawnpoint(editor)
-
-    editor.copy_actor(
-        name_of_scenario, (-1350.0, -10200.0, 0.0), trigger, name_of_trigger, 0,
-    )
-
-    spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (-953.0, -9790.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
-    )
-
-    scenario_surface.add_actor_to_entity_groups("collision_camera_024", name_of_trigger)
-    scenario_surface.add_actor_to_entity_groups("collision_camera_024", name_of_spawnpoint)
-
-    trigger_actor = scenario_surface.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
-    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Alpha_001"
-
-    spawnpoint_actor["rotation"][1] = -90
-
-
-def _create_checkpoint_alpha_003_area2(editor: PatcherEditor):
-    name_of_scenario = "s020_area2"
-    scenario_2 = editor.get_scenario(name_of_scenario)
-    name_of_trigger = "TG_SetCheckpoint_002_Alpha_003"
-    name_of_spawnpoint = "ST_SG_Alpha_003B"
-    name_of_spawnpoint_out = "ST_SG_Alpha_003B_Out"
-
-    trigger = _get_trigger(editor)
-    spawnpoint = _get_spawnpoint(editor)
-
-    editor.copy_actor(
-        name_of_scenario, (-18550.0, -6100.0, 0.0), trigger, name_of_trigger, 0,
-    )
-
-    editor.copy_actor(
-        name_of_scenario, (-18800.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
-    )
-
-    spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (-18800.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
-    )
-
-    scenario_2.add_actor_to_entity_groups("collision_camera_028", name_of_trigger)
-    scenario_2.add_actor_to_entity_groups("collision_camera_028", name_of_spawnpoint)
-    scenario_2.add_actor_to_entity_groups("collision_camera_028", name_of_spawnpoint_out)
-
-    trigger_actor = scenario_2.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
-    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Alpha_003"
-
-    spawnpoint_actor["rotation"][1] = -90
-
-
-def _create_checkpoint_gamma_area2b(editor: PatcherEditor):
-    name_of_scenario = "s025_area2b"
-    scenario_2b = editor.get_scenario(name_of_scenario)
-    name_of_trigger = "TG_SetCheckpoint_002_Gamma_001"
-    name_of_spawnpoint = "ST_SG_Gamma_001B"
-    name_of_spawnpoint_out = "ST_SG_Gamma_001B_Out"
-
-    trigger = _get_trigger(editor)
-    spawnpoint = _get_spawnpoint(editor)
-
-    editor.copy_actor(
-        name_of_scenario, (-1800.0, -4500.0, 0.0), trigger, name_of_trigger, 0,
-    )
-
-    spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (-1550.0, -4500.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
-    )
-
-    editor.copy_actor(
-        name_of_scenario, (-1550.0, -4500.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
-    )
-
-    scenario_2b.add_actor_to_entity_groups("collision_camera039", name_of_trigger)
-    scenario_2b.add_actor_to_entity_groups("collision_camera039", name_of_spawnpoint)
-    scenario_2b.add_actor_to_entity_groups("collision_camera039", name_of_spawnpoint_out)
-
-    trigger_actor = scenario_2b.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
-    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Gamma_001"
-
-    spawnpoint_actor["rotation"][1] = -90
-
-
-def _create_checkpoint_alpha_area6(editor: PatcherEditor):
-    name_of_scenario = "s060_area6"
-    scenario_6 = editor.get_scenario(name_of_scenario)
-    name_of_trigger = "TG_SetCheckpoint_002_Alpha_001"
-    name_of_spawnpoint = "ST_SG_Alpha_001B"
-    name_of_spawnpoint_out = "ST_SG_Alpha_001B_Out"
-
-    trigger = _get_trigger(editor)
-    spawnpoint = _get_spawnpoint(editor)
-
-    editor.copy_actor(
-        name_of_scenario, (3100.0, -6100.0, 0.0), trigger, name_of_trigger, 0,
-    )
-
-    editor.copy_actor(
-        name_of_scenario, (2850.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
-    )
-
-    spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (2850.0, -6100.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
-    )
-
-    scenario_6.add_actor_to_entity_groups("collision_camera_015", name_of_trigger)
-    scenario_6.add_actor_to_entity_groups("collision_camera_015", name_of_spawnpoint)
-    scenario_6.add_actor_to_entity_groups("collision_camera_015", name_of_spawnpoint_out)
-
-    trigger_actor = scenario_6.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
-    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Alpha_001"
-
-    spawnpoint_actor["rotation"][1] = -90
-
-
-def _create_checkpoint_zeta_area7(editor: PatcherEditor):
-    name_of_scenario = "s070_area7"
-    scenario_7 = editor.get_scenario(name_of_scenario)
-    name_of_trigger = "TG_SetCheckpoint_002_Zeta_001"
-    name_of_spawnpoint = "ST_SG_Zeta_001B"
-    name_of_spawnpoint_out = "ST_SG_Zeta_001B_Out"
-
-    trigger = _get_trigger(editor)
-    spawnpoint = _get_spawnpoint(editor)
-
-    editor.copy_actor(
-        name_of_scenario, (6600.0, 7500.0, 0.0), trigger, name_of_trigger, 0,
-    )
-
-    spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (6850.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
-    )
-
-    editor.copy_actor(
-        name_of_scenario, (6850.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
-    )
-
-    scenario_7.add_actor_to_entity_groups("collision_camera_040", name_of_trigger)
-    scenario_7.add_actor_to_entity_groups("collision_camera_040", name_of_spawnpoint)
-    scenario_7.add_actor_to_entity_groups("collision_camera_040", name_of_spawnpoint_out)
-
-    trigger_actor = scenario_7.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
-    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Zeta_001"
-
-    spawnpoint_actor["rotation"][1] = -90
-
-
-def _create_checkpoint_omega_area7_out(editor: PatcherEditor):
-    name_of_scenario = "s070_area7"
-    scenario_7 = editor.get_scenario(name_of_scenario)
-    name_of_spawnpoint_out = "ST_SG_Omega_001_Out"
-
-    spawnpoint = _get_spawnpoint(editor)
-
-    editor.copy_actor(
-        name_of_scenario, (2400.0, 7600.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
-    )
-
-    scenario_7.add_actor_to_entity_groups("collision_camera_047", name_of_spawnpoint_out)
-
-
-def _create_checkpoint_omega_area7_left(editor: PatcherEditor):
-    name_of_scenario = "s070_area7"
-    scenario_7 = editor.get_scenario(name_of_scenario)
-    name_of_trigger = "TG_SetCheckpoint_002_Omega_001"
-    name_of_spawnpoint = "ST_SG_Omega_001B"
-    name_of_spawnpoint_out = "ST_SG_Omega_001B_Out"
-
-    trigger = _get_trigger(editor)
-    spawnpoint = _get_spawnpoint(editor)
-
-    editor.copy_actor(
-        name_of_scenario, (-2000.0, 7500.0, 0.0), trigger, name_of_trigger, 0,
-    )
-
-    editor.copy_actor(
-        name_of_scenario, (-2250.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
-    )
-
-    spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (-2250.0, 7500.0, 0.0), spawnpoint, name_of_spawnpoint_out, 5,
-    )
-
-    scenario_7.add_actor_to_entity_groups("collision_camera_046", name_of_trigger)
-    scenario_7.add_actor_to_entity_groups("collision_camera_046", name_of_spawnpoint)
-    scenario_7.add_actor_to_entity_groups("collision_camera_046", name_of_spawnpoint_out)
-
-    trigger_actor = scenario_7.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
-    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_002_Omega_001"
-
-    spawnpoint_actor["rotation"][1] = -90
-
-
-def _create_checkpoint_omega_area7_top(editor: PatcherEditor):
-    name_of_scenario = "s070_area7"
-    scenario_7 = editor.get_scenario(name_of_scenario)
-    name_of_trigger = "TG_SetCheckpoint_003_Omega_001"
-    name_of_spawnpoint = "ST_SG_Omega_001C"
-
-    trigger = _get_trigger(editor)
-    spawnpoint = _get_spawnpoint(editor)
-
-    editor.copy_actor(
-        name_of_scenario, (-1025.0, 9700.0, 0.0), trigger, name_of_trigger, 0,
-    )
-
-    spawnpoint_actor = editor.copy_actor(
-        name_of_scenario, (-1025.0, 9700.0, 0.0), spawnpoint, name_of_spawnpoint, 5,
-    )
-
-    scenario_7.add_actor_to_entity_groups("collision_camera_061", name_of_trigger)
-    scenario_7.add_actor_to_entity_groups("collision_camera_061", name_of_spawnpoint)
-
-    trigger_actor = scenario_7.raw.actors[0][name_of_trigger]["components"][0]["arguments"]
-    trigger_actor[3]["value"] = "CurrentScenario.OnEnter_SetCheckpoint_003_Omega_001"
-
-    spawnpoint_actor["rotation"][1] = -90
+class NewStartPoint(typing.NamedTuple):
+    scenario: str
+    tg_name: str
+    tg_position: list[float]
+    st_name: str
+    st_position: list[float]
+    st_rotation: int
+    st_out_name: str
+    entity_groups: list[str]
+
+
+new_startpoints = [
+    NewStartPoint(
+        "s000_surface", "TG_SetCheckpoint_002_Alpha_001", [-1350.0, -10200.0, 0.0],
+        "ST_SG_Alpha_001B", [-953.0, -9790.0, 0.0], -90, None, ["collision_camera_024"]
+    ),
+    NewStartPoint(
+        "s020_area2", "TG_SetCheckpoint_002_Alpha_003", [-18550.0, -6100.0, 0.0],
+        "ST_SG_Alpha_003B", [-18800.0, -6100.0, 0.0], 90, "ST_SG_Alpha_003B_Out", ["collision_camera_028"]
+    ),
+    NewStartPoint(
+        "s025_area2b", "TG_SetCheckpoint_002_Gamma_001", [-1800.0, -4500.0, 0.0],
+        "ST_SG_Gamma_001B", [-1550.0, -4500.0, 0.0], -90, "ST_SG_Gamma_001B_Out", ["collision_camera039"]
+    ),
+    NewStartPoint(
+        "s060_area6", "TG_SetCheckpoint_002_Alpha_001", [3100.0, -6100.0, 0.0],
+        "ST_SG_Alpha_001B", [2850.0, -6100.0, 0.0], 90, "ST_SG_Alpha_001B_Out", ["collision_camera_015"]
+    ),
+    NewStartPoint(
+        "s070_area7", "TG_SetCheckpoint_002_Zeta_001", [6600.0, 7500.0, 0.0],
+        "ST_SG_Zeta_001B", [6850.0, 7500.0, 0.0], -90, "ST_SG_Zeta_001B_Out", ["collision_camera_040"]
+    ),
+    NewStartPoint(
+        "s070_area7", None, None,
+        None, [2400.0, 7600.0, 0.0], 90, "ST_SG_Omega_001_Out", ["collision_camera_047"]
+    ),
+    NewStartPoint(
+        "s070_area7", "TG_SetCheckpoint_002_Omega_001", [-2000.0, 7500.0, 0.0],
+        "ST_SG_Omega_001B", [-2250.0, 7500.0, 0.0], 90, "ST_SG_Omega_001B_Out", ["collision_camera_046"]
+    ),
+    NewStartPoint(
+        "s070_area7", "TG_SetCheckpoint_003_Omega_001", [-1025.0, 9700.0, 0.0],
+        "ST_SG_Omega_001C", [-1025.0, 9700.0, 0.0], -90, None, ["collision_camera_061"]
+    ),
+]
+
+
+def add_startpoints(editor: PatcherEditor, new_startpoint: NewStartPoint):
+    template_tg = editor.get_scenario("s025_area2b").raw.actors[0]["TG_SetCheckpoint_001_Gamma_001"]
+    template_st = editor.get_scenario("s025_area2b").raw.actors[5]["ST_SG_Gamma_001"]
+
+    scenario_name = new_startpoint.scenario
+    scenario_file = editor.get_scenario(scenario_name)
+
+    # Copy the actors
+    if new_startpoint.tg_name is not None:
+        editor.copy_actor(scenario_name, new_startpoint.tg_position, template_tg, new_startpoint.tg_name, 0)
+    if new_startpoint.st_name is not None:
+        editor.copy_actor(scenario_name, new_startpoint.st_position, template_st, new_startpoint.st_name, 5)
+    if new_startpoint.st_out_name is not None:
+        editor.copy_actor(scenario_name, new_startpoint.st_position, template_st, new_startpoint.st_out_name, 5)
+
+    # Add to the entity groups
+    for entity_group in new_startpoint.entity_groups:
+        for actor in [new_startpoint.tg_name, new_startpoint.st_name, new_startpoint.st_out_name]:
+            if actor is not None:
+                scenario_file.add_actor_to_entity_groups(entity_group, actor, True)
+
+    # Rotate the startpoint actors
+    if new_startpoint.st_name is not None:
+        scenario_file.raw.actors[5][new_startpoint.st_name]["rotation"][1] = new_startpoint.st_rotation
+        if new_startpoint.st_out_name is not None:
+            scenario_file.raw.actors[5][new_startpoint.st_out_name]["rotation"][1] = (
+            -abs(new_startpoint.st_rotation)
+            if new_startpoint.st_rotation == 90
+            else abs(new_startpoint.st_rotation)
+        )
+    # Edge case where startpoint actors aren't being added but startpoint_out actors are
+    if new_startpoint.st_out_name == "ST_SG_Omega_001_Out":
+        scenario_file.raw.actors[5][new_startpoint.st_out_name]["rotation"][1] = new_startpoint.st_rotation
+
+    # Update the trigger actor
+    if new_startpoint.tg_name is not None:
+        scenario_file.raw.actors[0][new_startpoint.tg_name]["components"][0][
+            "arguments"
+        ][3]["value"] = ("CurrentScenario.OnEnter_" + new_startpoint.tg_name[3:])
 
 
 def patch_metroids(editor: PatcherEditor):
     _patch_metroids(editor)
-    _create_checkpoint_alpha_surface(editor)
-    _create_checkpoint_alpha_003_area2(editor)
-    _create_checkpoint_gamma_area2b(editor)
-    _create_checkpoint_alpha_area6(editor)
-    _create_checkpoint_zeta_area7(editor)
-    _create_checkpoint_omega_area7_out(editor)
-    _create_checkpoint_omega_area7_left(editor)
-    _create_checkpoint_omega_area7_top(editor)
+    for new_startpoint in new_startpoints:
+        add_startpoints(editor, new_startpoint)


### PR DESCRIPTION
The custom Metroid checkpoints now use a class instead of being individually added. Honestly, this pr might be overkill since I doubt we'd actually add more checkpoints, but could be useful in the future for adding extra boss checkpoints. Either way, cleans up the code a bit so that's a plus.