### PR TITLE
Fully ensure PBs can't be used when entering the Diggernaut fight

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s070_area7.lua
+++ b/src/open_samus_returns_rando/files/levels/s070_area7.lua
@@ -856,6 +856,7 @@ function s070_area7.LaunchManicMinerBotIntroCutscene()
     local PreFightPBMax = Game.GetItemAmount(Game.GetPlayerName(), "ITEM_WEAPON_POWER_BOMB_MAX")
     Game.SetItemAmount(Game.GetPlayerName(), "ITEM_WEAPON_POWER_BOMB", 0)
     Game.SetItemAmount(Game.GetPlayerName(), "ITEM_WEAPON_POWER_BOMB_MAX", 0)
+    Game.SetItemAmount(Game.GetPlayerName(), "ITEM_WEAPON_POWER_BOMB_CURRENT", 0)
     Game.SetItemAmount(Game.GetPlayerName(), "ITEM_POWER_BOMB_TANKS", PreFightPBMax)
   end
 end
@@ -900,6 +901,7 @@ function s070_area7.OnStartManicMinerBotDeathCutscene()
     local locked_pbs = Game.GetItemAmount(Game.GetPlayerName(), "ITEM_POWER_BOMB_TANKS")
     Game.SetItemAmount(Game.GetPlayerName(), "ITEM_WEAPON_POWER_BOMB", 1)
     Game.SetItemAmount(Game.GetPlayerName(), "ITEM_WEAPON_POWER_BOMB_MAX", locked_pbs)
+    Game.SetItemAmount(Game.GetPlayerName(), "ITEM_WEAPON_POWER_BOMB_CURRENT", locked_pbs)
     Game.SetItemAmount(Game.GetPlayerName(), "ITEM_POWER_BOMB_TANKS", 0)
   end
 end


### PR DESCRIPTION
Fixes #348 