### PR TITLE
Fix ice beam minimap issue

### DIFF
--- a/src/open_samus_returns_rando/specific_patches/door_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/door_patches.py
@@ -255,7 +255,7 @@ class DoorType(Enum):
     ICE_BEAM = ("ice_beam", ActorData.DOOR_POWER, "doorice", True, ActorData.SHIELD_ICE_BEAM, [
         "actors/props/doorshield", "actors/props/doorcreature", "actors/props/doorshieldicebeam",
         "sounds/props/creaturedoor", "system/fx/textures/blood_gray.bctex",
-    ])
+    ], 180.0)
     GRAPPLE_BEAM = ("grapple_beam", ActorData.DOOR_POWER, "doorgrapple", True, ActorData.SHIELD_GRAPPLE_BEAM, [
         "actors/props/doorshield", "actors/props/doorshieldgrapplebeam",
         "sounds/props/doorchargecharge/missiledoor_hum.bcwav"


### PR DESCRIPTION
Wow, I should have seen when reviewing it.
Plasma doors have the weirdness of them being rotated by 180.0 by default.
All doors are facing left normally but that one is facing right. So, we need to apply a rotation to it because otherwise our logic is bugged and you actually see the ice beam cover intended to be on the right side on the left side.
Fixes #350