### PR TITLE
Patch A4 CM collision for DLR Support

### DIFF
--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -282,18 +282,18 @@ def fix_wrong_cc_actor_deletions(editor: PatcherEditor) -> None:
             bmsbk_cc_obj = next(cc_obj for cc_obj in bmsbk.raw.collision_cameras if cc_name in cc_obj.name)
             bmsbk_cc_obj.entries.append(len(bmsbk.raw.block_groups) - 1)
 
-            
+
 def patch_area7_item(editor: PatcherEditor) -> None:
     area7 = editor.get_scenario("s090_area9")
     area7.add_actor_to_entity_groups("PostOmega_003", "LE_Item_009")
 
-    
+
 def patch_a4_collision(editor: PatcherEditor) -> None:
     # Extends the collision cc11 -> cc1 to allow for the upper path to be included in DLR
     area4 = editor.get_file("maps/levels/c10_samus/s050_area5/s050_area5.bmscd", Bmscc)
     area4.raw["layers"][0]["entries"][0]["data"]["polys"][0]["points"][327]["x"] = 750.0
 
-    
+
 def patch_a1_teleporter_crumbles(editor: PatcherEditor) -> None:
     # Prevents a possible softlock in DLR if a door is added to the teleporter room
     area1 = editor.get_file("maps/levels/c10_samus/s010_area1/s010_area1.bmsbk", Bmsbk)

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -288,12 +288,9 @@ def patch_area7_item(editor: PatcherEditor) -> None:
 
 
 def patch_a4_collision(editor: PatcherEditor) -> None:
-    # Extends the collision leading into cc1 from cc11 to allow for the upper path to be included in DLR
+    # Extends the collision cc11 -> cc1 to allow for the upper path to be included in DLR
     area4 = editor.get_file("maps/levels/c10_samus/s050_area5/s050_area5.bmscd", Bmscc)
-    points = area4.raw["layers"][0]["entries"][0]["data"]["polys"][0]["points"]
-    points[326]["x"] = 800.0
-    points[326]["y"] = -1900.0
-    points[327]["x"] = 800.0
+    area4.raw["layers"][0]["entries"][0]["data"]["polys"][0]["points"][327]["x"] = 750.0
 
 
 def apply_static_fixes(editor: PatcherEditor) -> None:

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -2,7 +2,7 @@ import copy
 import typing
 
 from construct import Container, ListContainer
-from mercury_engine_data_structures.formats import Bmsad, Bmsbk, Bmtun
+from mercury_engine_data_structures.formats import Bmsad, Bmsbk, Bmscc, Bmtun
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 MULTI_ROOM_GAMMAS = [
@@ -286,6 +286,16 @@ def patch_area7_item(editor: PatcherEditor) -> None:
     area7 = editor.get_scenario("s090_area9")
     area7.add_actor_to_entity_groups("PostOmega_003", "LE_Item_009")
 
+
+def patch_a4_collision(editor: PatcherEditor) -> None:
+    # Extends the collision leading into cc1 from cc11 to allow for the upper path to be included in DLR
+    area4 = editor.get_file("maps/levels/c10_samus/s050_area5/s050_area5.bmscd", Bmscc)
+    points = area4.raw["layers"][0]["entries"][0]["data"]["polys"][0]["points"]
+    points[326]["x"] = 800.0
+    points[326]["y"] = -1900.0
+    points[327]["x"] = 800.0
+
+
 def apply_static_fixes(editor: PatcherEditor) -> None:
     patch_multi_room_gammas(editor)
     patch_pickup_rotation(editor)
@@ -297,3 +307,4 @@ def apply_static_fixes(editor: PatcherEditor) -> None:
     increase_pb_drop_chance(editor)
     fix_wrong_cc_actor_deletions(editor)
     patch_area7_item(editor)
+    patch_a4_collision(editor)


### PR DESCRIPTION
The obstruction in `collision_camera_011` was actually because the pre-chase state is still active initially, so this extends the collision so `collision_camera_001` can be entered in this state. This also allows for the one-way door to be shuffled in DLR.

Fixes #345 

![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/e049d521-2b62-4089-9e1e-3af96aada2d9)
Before:
![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/503c4a2f-f574-4fc2-b5c0-cc6ed114785e)
After:
![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/45d7c0ce-ca5d-4d48-a8d5-c8d9b6cde244)


