### PR TITLE
Rotate Wave Beam and High Jump Boots if progressive

### DIFF
--- a/src/open_samus_returns_rando/files/custom/scenario.lua
+++ b/src/open_samus_returns_rando/files/custom/scenario.lua
@@ -27,7 +27,7 @@ function Scenario._UpdateProgressiveItemModels()
         if not has_item or #progressive_models == index then
           local pickup = Game.GetEntity(name)
           pickup.MODELUPDATER.sModelAlias = model.alias
-          -- If the model is Wave Beam or High Jump Boots, rotate to face right
+          -- Rotate Wave Beam and High Jump Boots to face right
           if index == 1 then
             pickup.vAng = V3D(0, 1.5, 0)
           end

--- a/src/open_samus_returns_rando/files/custom/scenario.lua
+++ b/src/open_samus_returns_rando/files/custom/scenario.lua
@@ -27,6 +27,10 @@ function Scenario._UpdateProgressiveItemModels()
         if not has_item or #progressive_models == index then
           local pickup = Game.GetEntity(name)
           pickup.MODELUPDATER.sModelAlias = model.alias
+          -- If the model is Wave Beam or High Jump Boots, rotate to face right
+          if index == 1 then
+            pickup.vAng = V3D(0, 1.5, 0)
+          end
           break
         end
       end


### PR DESCRIPTION
If progressives are enabled and the model is either Wave Beam or High Jump Boots, the model will now face to the right to be more easily identifiable.

Related to #75 (Should close the issue after this)

Wave Beam
![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/e840587d-0880-4f8e-b80b-b5a1fcb7ed1a)

High Jump Boots
![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/0f8b5024-9e7b-4fbc-ad87-fd120bedb557)
