### PR TITLE
Add support for constant heat/lava damage

### DIFF
--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -301,6 +301,24 @@
             },
             "additionalProperties": false
         },
+        "constant_environment_damage": {
+            "description": "Each property, when not null, will change the damage from that type to be that much per second",
+            "default": {},
+            "type": "object",
+            "properties": {
+                "heat": {
+                    "title": "Heated Rooms",
+                    "$ref": "#/$defs/constant_damage_value",
+                    "default": null
+                },
+                "lava": {
+                    "title": "Lava",
+                    "$ref": "#/$defs/constant_damage_value",
+                    "default": null
+                }
+            },
+            "additionalProperties": false
+        },
         "debug_spawn_points": {
             "type": "array",
             "description": "Creates new spawn points for debugging",
@@ -699,6 +717,19 @@
             "required": [
                 "scenario",
                 "spawngroup"
+            ]
+        },
+        "constant_damage_value": {
+            "default": null,
+            "anyOf": [
+                {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1000
+                },
+                {
+                    "type": "null"
+                }
             ]
         }
     }

--- a/src/open_samus_returns_rando/samus_returns_patcher.py
+++ b/src/open_samus_returns_rando/samus_returns_patcher.py
@@ -21,6 +21,7 @@ from open_samus_returns_rando.pickups.pickup import patch_pickups
 from open_samus_returns_rando.specific_patches import cosmetic_patches, game_patches, tunable_patches
 from open_samus_returns_rando.specific_patches.chozo_seal_patches import patch_chozo_seals
 from open_samus_returns_rando.specific_patches.door_patches import patch_doors
+from open_samus_returns_rando.specific_patches.environmental_damage import apply_constant_damage
 from open_samus_returns_rando.specific_patches.heat_room_patches import patch_heat_rooms
 from open_samus_returns_rando.specific_patches.hint_patches import patch_hints
 from open_samus_returns_rando.specific_patches.map_icons import patch_tiles
@@ -96,6 +97,9 @@ def patch_extracted(input_path: Path, input_exheader: Path | None, output_path: 
 
     # Fix unheated heat rooms
     patch_heat_rooms(editor)
+
+    # Environmental Damage
+    apply_constant_damage(editor, configuration["constant_environment_damage"])
 
     # Patch door types and make shields on both sides
     patch_doors(editor, configuration["door_patches"], configuration["custom_doors"])

--- a/src/open_samus_returns_rando/specific_patches/environmental_damage.py
+++ b/src/open_samus_returns_rando/specific_patches/environmental_damage.py
@@ -1,0 +1,26 @@
+from open_samus_returns_rando.patcher_editor import PatcherEditor
+from open_samus_returns_rando.specific_patches.environmental_damage_sources import ALL_DAMAGE_ROOM_ACTORS
+
+
+def apply_constant_damage(editor: PatcherEditor, configuration: dict) -> None:
+    for reference in ALL_DAMAGE_ROOM_ACTORS:
+        actor = editor.resolve_actor_reference(reference)
+
+        if actor["components"][1]["arguments"][26]["value"] == "HEAT":
+            config_field = "heat"
+        elif actor["components"][1]["arguments"][26]["value"] == "LAVA":
+            config_field = "lava"
+        else:
+            raise ValueError(f"{reference} does not have a valid actorDef for environmental damage")
+
+        if configuration[config_field] is None:
+            continue
+
+        damage = configuration[config_field]
+
+        # Max damage per tick
+        actor["components"][1]["arguments"][19]["value"] = damage
+        # Damage Scale
+        actor["components"][1]["arguments"][28]["value"] = damage
+        # Damage of first tick. Set to half to give room for player error
+        actor["components"][2]["arguments"][19]["value"] = damage / 2

--- a/src/open_samus_returns_rando/specific_patches/environmental_damage_sources.py
+++ b/src/open_samus_returns_rando/specific_patches/environmental_damage_sources.py
@@ -1,0 +1,199 @@
+import itertools
+
+_AREA_1_HEAT_ACTORS = [
+    {
+        "scenario": "s010_area1",
+        "layer": 2,
+        "actor": "TG_Heat_001"
+    }
+]
+
+_AREA_1_LAVA_ACTORS = [
+    {
+        "scenario": "s010_area1",
+        "layer": 0,
+        "actor": "Lava_Trigger_001"
+    }
+]
+
+_AREA_2_HEAT_ACTORS = [
+    {
+        "scenario": "s020_area2",
+        "layer": 2,
+        "actor": "TG_SP_Heat_001"
+    },
+    {
+        "scenario": "s020_area2",
+        "layer": 0,
+        "actor": "TG_Heat_002"
+    },
+    {
+        "scenario": "s025_area2b",
+        "layer": 2,
+        "actor": "TG_SP_Heat_001"
+    }
+]
+
+_AREA_2_LAVA_ACTORS = [
+    {
+        "scenario": "s020_area2",
+        "layer": 0,
+        "actor": "TG_Lava_001"
+    },
+    {
+        "scenario": "s020_area2",
+        "layer": 0,
+        "actor": "TG_Lava_002"
+    },
+    {
+        "scenario": "s020_area2",
+        "layer": 0,
+        "actor": "TG_Lava_003"
+    },
+    {
+        "scenario": "s020_area2",
+        "layer": 0,
+        "actor": "TG_Lava_004"
+    }
+]
+
+_AREA_3_HEAT_ACTORS = [
+    {
+        "scenario": "s033_area3b",
+        "layer": 2,
+        "actor": "TG_Heat_Rando_001"
+    },
+    {
+        "scenario": "s036_area3c",
+        "layer": 2,
+        "actor": "TG_Heat_Rando_001"
+    }
+]
+
+_AREA_3_LAVA_ACTORS = [
+    {
+        "scenario": "s033_area3b",
+        "layer": 0,
+        "actor": "TG_Lava_001"
+    },
+    {
+        "scenario": "s033_area3b",
+        "layer": 0,
+        "actor": "TG_Lava_002"
+    },
+    {
+        "scenario": "s036_area3c",
+        "layer": 0,
+        "actor": "TG_Lava_001"
+    },
+    {
+        "scenario": "s036_area3c",
+        "layer": 0,
+        "actor": "TG_Lava_002"
+    }
+]
+
+_AREA_4_HEAT_ACTORS = [
+    {
+        "scenario": "s040_area4",
+        "layer": 2,
+        "actor": "TG_Heat_Rando_001"
+    },
+    {
+        "scenario": "s050_area5",
+        "layer": 2,
+        "actor": "TG_Heat_Rando_001"
+    },
+    {
+        "scenario": "s050_area5",
+        "layer": 2,
+        "actor": "TG_Heat_Rando_002"
+    }
+]
+
+_AREA_4_LAVA_ACTORS = [
+    {
+        "scenario": "s040_area4",
+        "layer": 0,
+        "actor": "TG_Lava_001"
+    },
+    {
+        "scenario": "s040_area4",
+        "layer": 0,
+        "actor": "TG_Lava_002"
+    },
+    {
+        "scenario": "s040_area4",
+        "layer": 0,
+        "actor": "TG_Lava_003"
+    },
+    {
+        "scenario": "s050_area5",
+        "layer": 0,
+        "actor": "TG_Lava_001"
+    },
+    {
+        "scenario": "s050_area5",
+        "layer": 0,
+        "actor": "TG_Lava_003"
+    },
+    {
+        "scenario": "s050_area5",
+        "layer": 0,
+        "actor": "TG_Lava_005"
+    }
+]
+
+_AREA_5_HEAT_ACTORS = [
+    {
+        "scenario": "s065_area6b",
+        "layer": 2,
+        "actor": "TG_Heat_Rando_001"
+    },
+    {
+        "scenario": "s067_area6c",
+        "layer": 2,
+        "actor": "TG_Heat_Rando_001"
+    }
+]
+
+_AREA_5_LAVA_ACTORS = [
+    {
+        "scenario": "s065_area6b",
+        "layer": 0,
+        "actor": "TG_Lava_001"
+    },
+    {
+        "scenario": "s067_area6c",
+        "layer": 0,
+        "actor": "TG_Lava_001"
+    },
+    {
+        "scenario": "s067_area6c",
+        "layer": 0,
+        "actor": "TG_Lava_002"
+    },
+    {
+        "scenario": "s067_area6c",
+        "layer": 0,
+        "actor": "TG_Lava_003"
+    },
+    {
+        "scenario": "s067_area6c",
+        "layer": 0,
+        "actor": "TG_Lava_004"
+    }
+]
+
+ALL_DAMAGE_ROOM_ACTORS = list(itertools.chain(
+    _AREA_1_HEAT_ACTORS,
+    _AREA_1_LAVA_ACTORS,
+    _AREA_2_HEAT_ACTORS,
+    _AREA_2_LAVA_ACTORS,
+    _AREA_3_HEAT_ACTORS,
+    _AREA_3_LAVA_ACTORS,
+    _AREA_4_HEAT_ACTORS,
+    _AREA_4_LAVA_ACTORS,
+    _AREA_5_HEAT_ACTORS,
+    _AREA_5_LAVA_ACTORS,
+))


### PR DESCRIPTION
Setting the third field to be `damage / 2` is completely arbitrary. Could just set it to be damage.