### PR TITLE
Attempted fix for Reverse Area 8 crash

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/src/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -226,7 +226,9 @@ function s100_area10.OnMetroidDead()
       "collision_camera_019"
     }) do
       print(_FORV_7_)
-      Game.SetSubAreaCurrentSetup(_FORV_7_, "PostMetroids_001", true)
+      if Game.GetEntity("LE_ValveQueen") ~= nil then
+        Game.SetSubAreaCurrentSetup(_FORV_7_, "PostMetroids_001", true)
+      end
     end
     for _FORV_7_, _FORV_8_ in pairs({
       "SpawnGroup029",

--- a/src/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/src/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -222,7 +222,6 @@ function s100_area10.OnMetroidDead()
     Scenario.WriteToBlackboard("QueenDiscovered", "b", true)
     Game.AddSF(3.5, "s100_area10.ScheduledQueenRoar", "")
     for _FORV_6_, _FORV_7_ in pairs({
-      "collision_camera_008",
       "collision_camera_013",
       "collision_camera_014",
       "collision_camera_015",
@@ -231,9 +230,7 @@ function s100_area10.OnMetroidDead()
       "collision_camera_019"
     }) do
       print(_FORV_7_)
-      if Game.GetEntity("LE_ValveQueen") ~= nil then
-        Game.SetSubAreaCurrentSetup(_FORV_7_, "PostMetroids_001", true)
-      end
+      Game.SetSubAreaCurrentSetup(_FORV_7_, "PostMetroids_001", true)
     end
     for _FORV_7_, _FORV_8_ in pairs({
       "SpawnGroup029",

--- a/src/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/src/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -208,6 +208,7 @@ function s100_area10.OnLarva_010_Generated(_ARG_0_, _ARG_1_)
   end
 end
 function s100_area10.OnMetroidDead()
+  -- Disable the intro and the camera change triggers if a Metroid has been defeated, which means that Reverse Area 8 should be enabled
   Game.DisableTrigger("TG_Intro_Larva")
   if Game.GetEntity("TG_ChangeCamera_IntroLarva") ~= nil then
     Game.GetEntity("TG_ChangeCamera_IntroLarva").TRIGGER:DisableTrigger()

--- a/src/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/src/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -208,6 +208,10 @@ function s100_area10.OnLarva_010_Generated(_ARG_0_, _ARG_1_)
   end
 end
 function s100_area10.OnMetroidDead()
+  Game.DisableTrigger("TG_Intro_Larva")
+  if Game.GetEntity("TG_ChangeCamera_IntroLarva") ~= nil then
+    Game.GetEntity("TG_ChangeCamera_IntroLarva").TRIGGER:DisableTrigger()
+  end
   if Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") ~= nil and s100_area10.iNumMetroids == Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") then
     if Game.GetEntity("LE_ValveQueen") ~= nil then
       Game.GetEntity("LE_ValveQueen").MODELUPDATER:SetMeshVisible("Valve", false)


### PR DESCRIPTION
Current attempt to fix the crash for Reverse Area 8 in RomFS mode. Related to #378

This solution currently checks if the Queen wall exists or not (essentially if RA8 is enabled or disabled). If the option is disabled, vanilla behavior occurs, and the ccs will update their setups when all the Metroids are dead. If it's enabled, never update the setups.

It would be nice to know why this breaks with RomFS mode and not PKG mode instead of doing this, as this is not the most elegant solution, but it does get the job done.