### PR TITLE
Add hint for Baby location on collected all DNA textbox

### DIFF
--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -386,19 +386,34 @@
         "hints": {
             "type": "array",
             "items": {
-                "type": "object",
-                "properties": {
-                    "accesspoint_actor": {
-                        "$ref": "#/$defs/actor_reference"
-                    },
-                    "text": {
-                        "type": "string"
+                "if": {
+                    "properties": {
+                        "baby_metroid_hint": {
+                            "maxProperties": 1
+                        }
                     }
                 },
-                "required": [
-                    "accesspoint_actor",
-                    "text"
-                ]
+                "then": {
+                    "properties": {
+                        "text": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "else": {
+                    "properties": {
+                        "accesspoint_actor": {
+                            "$ref": "#/$defs/actor_reference"
+                        },
+                        "text": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "accesspoint_actor",
+                        "text"
+                    ]
+                }
             },
             "default": []
         },

--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -386,36 +386,26 @@
         "hints": {
             "type": "array",
             "items": {
-                "if": {
-                    "properties": {
-                        "baby_metroid_hint": {
-                            "maxProperties": 1
-                        }
-                    }
-                },
-                "then": {
-                    "properties": {
-                        "text": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "else": {
-                    "properties": {
-                        "accesspoint_actor": {
-                            "$ref": "#/$defs/actor_reference"
-                        },
-                        "text": {
-                            "type": "string"
-                        }
+                "type": "object",
+                "properties": {
+                    "accesspoint_actor": {
+                        "$ref": "#/$defs/actor_reference"
                     },
-                    "required": [
-                        "accesspoint_actor",
-                        "text"
-                    ]
-                }
+                    "text": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "accesspoint_actor",
+                    "text"
+                ]
             },
             "default": []
+        },
+        "baby_metroid_hint": {
+            "description": "Hint for where the Baby Metroid is located.",
+            "type": "string",
+            "default": {}
         },
         "cosmetic_patches": {
             "type": "object",

--- a/src/open_samus_returns_rando/files/templates/custom_init.lua
+++ b/src/open_samus_returns_rando/files/templates/custom_init.lua
@@ -32,6 +32,7 @@ Init.sLayoutUUID = TEMPLATE("layout_uuid")
 Init.sThisRandoIdentifier = TEMPLATE("configuration_identifier") .. Init.sLayoutUUID
 Init.tBoxesSeen = 0
 Init.bEnableRoomIds = TEMPLATE("enable_room_ids")
+Init.sBabyMetroidHint = TEMPLATE("baby_metroid_hint")
 
 local orig_log = Game.LogWarn
 if TEMPLATE("enable_remote_lua") then

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -103,7 +103,7 @@ function RandomizerPowerup.ObjectiveComplete()
             GUI.LaunchMessage("All Metroid DNA has been collected!\nThe path to Proteus Ridley has been opened in Surface West!",
                 "RandomizerPowerup.Dummy", "")
         elseif baby == 0 then
-            GUI.LaunchMessage("All Metroid DNA has been collected!\nContinue searching for the Baby Metroid!",
+            GUI.LaunchMessage("All Metroid DNA has been collected!\n" .. Init.sBabyMetroidHint,
                 "RandomizerPowerup.Dummy", "")
         end
     end

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -257,9 +257,8 @@ class LuaEditor:
 
 
         baby_metroid_hint = lua_util.wrap_string("Continue searching for the Baby Metroid.")
-        for hint in configuration["hints"]:
-            if "baby_metroid_hint" in hint:
-                baby_metroid_hint = lua_util.wrap_string(hint["baby_metroid_hint"]["text"])
+        if "baby_metroid_hint" in configuration:
+            baby_metroid_hint = lua_util.wrap_string(configuration["baby_metroid_hint"])
 
         replacement = {
             "new_game_inventory": final_inventory,

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -255,6 +255,12 @@ class LuaEditor:
         if "layout_uuid" in configuration:
             layout_uuid = lua_util.wrap_string(configuration["layout_uuid"])
 
+
+        baby_metroid_hint = lua_util.wrap_string("Continue searching for the Baby Metroid.")
+        for hint in configuration["hints"]:
+            if "baby_metroid_hint" in hint:
+                baby_metroid_hint = lua_util.wrap_string(hint["baby_metroid_hint"]["text"])
+
         replacement = {
             "new_game_inventory": final_inventory,
             "starting_scenario": lua_util.wrap_string(starting_location["scenario"]),
@@ -268,6 +274,7 @@ class LuaEditor:
             "enable_room_ids": False if cosmetic_options["enable_room_name_display"] == "NEVER" else True,
             "layout_uuid": layout_uuid,
             "enable_remote_lua": enable_remote_lua,
+            "baby_metroid_hint": baby_metroid_hint
         }
 
         return lua_util.replace_lua_template("custom_init.lua", replacement)

--- a/src/open_samus_returns_rando/specific_patches/hint_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/hint_patches.py
@@ -3,4 +3,6 @@ from open_samus_returns_rando.lua_editor import LuaEditor
 
 def patch_hints(lua_scripts: LuaEditor, hints: list) -> None:
     for hint in hints:
+        if "baby_metroid_hint" in hint:
+            continue
         lua_scripts.add_hint(hint)

--- a/src/open_samus_returns_rando/specific_patches/hint_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/hint_patches.py
@@ -3,6 +3,4 @@ from open_samus_returns_rando.lua_editor import LuaEditor
 
 def patch_hints(lua_scripts: LuaEditor, hints: list) -> None:
     for hint in hints:
-        if "baby_metroid_hint" in hint:
-            continue
         lua_scripts.add_hint(hint)

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -4237,6 +4237,11 @@
                 "actor": "LE_RandoDNA"
             },
             "text": "Metroid DNA is located in Area 5 - Tower Exterior - Red Plant Maze.\n"
+        },
+        {
+            "baby_metroid_hint": {
+                "text": "Baby noises have been reported in Surface East."
+            }
         }
     ],
     "cosmetic_patches": {

--- a/tests/test_files/starter_preset_patcher.json
+++ b/tests/test_files/starter_preset_patcher.json
@@ -4237,13 +4237,9 @@
                 "actor": "LE_RandoDNA"
             },
             "text": "Metroid DNA is located in Area 5 - Tower Exterior - Red Plant Maze.\n"
-        },
-        {
-            "baby_metroid_hint": {
-                "text": "Baby noises have been reported in Surface East."
-            }
         }
     ],
+    "baby_metroid_hint": "Baby noises have been reported in Surface East.",
     "cosmetic_patches": {
         "laser_locked_color": [
             1.0,


### PR DESCRIPTION
Reads a string from the configuration which replaces the second sentence with a Baby hint. Will be configurable in Randovania to choose between no hint (current behavior), area only, or precise. Useful as a last resort if in go mode otherwise, or if a Baby hint is not provided

![image](https://github.com/randovania/open-samus-returns-rando/assets/38679103/56c160b9-5e77-4cdb-84ef-24f247b493c7)
