### PR TITLE
Disable problematic vignettes

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s010_area1.lua
+++ b/src/open_samus_returns_rando/files/levels/s010_area1.lua
@@ -38,6 +38,7 @@ function s010_area1.SetupDebugGameBlackboard()
   Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_SPECIAL_ENERGY_PHASE_DISPLACEMENT", "f", 0)
 end
 function s010_area1.InitFromBlackboard()
+  Game.SetSceneGroupEnabledByName("sg_vignette_201", false)
   if Scenario.ReadFromBlackboard("Alpha_PreSpawn11Event", false) then
     if Game.GetEntity("LE_Alpha_PreSpawn11Event") ~= nil then
       Game.GetEntity("LE_Alpha_PreSpawn11Event"):DelMe()

--- a/src/open_samus_returns_rando/files/levels/s030_area3.lua
+++ b/src/open_samus_returns_rando/files/levels/s030_area3.lua
@@ -236,6 +236,7 @@ function s030_area3.ElevatorSetTarget(_ARG_0_)
   end
 end
 function s030_area3.InitFromBlackboard()
+  Game.SetSceneGroupEnabledByName("sg_vignette_03", false)
   if Game.GetEntity("LE_Event_03") ~= nil and Scenario.ReadFromBlackboard("SpecialEvent03Launched") then
     Game.GetEntity("LE_Event_03"):Disable()
   end

--- a/src/open_samus_returns_rando/files/levels/s040_area4.lua
+++ b/src/open_samus_returns_rando/files/levels/s040_area4.lua
@@ -341,6 +341,7 @@ function s040_area4.SetupDebugGameBlackboard()
   Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_SPECIAL_ENERGY_PHASE_DISPLACEMENT", "f", 0)
 end
 function s040_area4.InitFromBlackboard()
+  Game.SetSceneGroupEnabledByName("sg_vignette_003", false)
   Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_001", true)
   Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_002", true)
   if Blackboard.GetProp("s040_area4", "entity_LE_HazarousPool_001_enabled") == nil then

--- a/src/open_samus_returns_rando/files/levels/s090_area9.lua
+++ b/src/open_samus_returns_rando/files/levels/s090_area9.lua
@@ -113,6 +113,7 @@ function s090_area9.ElevatorSetTarget(_ARG_0_)
   end
 end
 function s090_area9.InitFromBlackboard()
+  Game.SetSceneGroupEnabledByName("sg_vignette_005", false)
   s090_area9.bAfterOmegasKilledMusicChange = false
   s090_area9.AllOmegasDeadCallback()
   s090_area9.OnFansInit()


### PR DESCRIPTION
Vignettes are used to hide sections, and normally aren't an issue. However, with random start/elevators/tricks, some of them become a hindrance and obstruct the player's view. This removes the most problematic ones. More could be removed later if desired.

A1: Break the Bomb Block in the Alpha Arena
![Metroid Samus Returns_27 06 24_23 17 08 806](https://github.com/randovania/open-samus-returns-rando/assets/38679103/43bde7b4-7e1c-4c4d-bbfc-011b552fd234)

A3: Break a shot block below the statue
![Metroid Samus Returns_27 06 24_23 15 11 388](https://github.com/randovania/open-samus-returns-rando/assets/38679103/3ecc6e2b-f56a-4b11-a6ce-5c0eafd631df)

A4: Break the left Bomb Bomb next to Samus 
![Metroid Samus Returns_27 06 24_23 22 47 855](https://github.com/randovania/open-samus-returns-rando/assets/38679103/dcee242b-3ab1-4154-bd94-0a7c6b2450d9)

A7: Break a Bomb Block above the save to the right near the water
![Metroid Samus Returns_27 06 24_23 29 32 239](https://github.com/randovania/open-samus-returns-rando/assets/38679103/b2238f35-babd-42eb-8822-b96831da7b96)
