### PR TITLE
Fully remove problematic vignettes

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s010_area1.lua
+++ b/src/open_samus_returns_rando/files/levels/s010_area1.lua
@@ -38,7 +38,6 @@ function s010_area1.SetupDebugGameBlackboard()
   Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_SPECIAL_ENERGY_PHASE_DISPLACEMENT", "f", 0)
 end
 function s010_area1.InitFromBlackboard()
-  Game.SetSceneGroupEnabledByName("sg_vignette_201", false)
   if Scenario.ReadFromBlackboard("Alpha_PreSpawn11Event", false) then
     if Game.GetEntity("LE_Alpha_PreSpawn11Event") ~= nil then
       Game.GetEntity("LE_Alpha_PreSpawn11Event"):DelMe()

--- a/src/open_samus_returns_rando/files/levels/s030_area3.lua
+++ b/src/open_samus_returns_rando/files/levels/s030_area3.lua
@@ -236,7 +236,6 @@ function s030_area3.ElevatorSetTarget(_ARG_0_)
   end
 end
 function s030_area3.InitFromBlackboard()
-  Game.SetSceneGroupEnabledByName("sg_vignette_03", false)
   if Game.GetEntity("LE_Event_03") ~= nil and Scenario.ReadFromBlackboard("SpecialEvent03Launched") then
     Game.GetEntity("LE_Event_03"):Disable()
   end

--- a/src/open_samus_returns_rando/files/levels/s040_area4.lua
+++ b/src/open_samus_returns_rando/files/levels/s040_area4.lua
@@ -341,7 +341,6 @@ function s040_area4.SetupDebugGameBlackboard()
   Blackboard.SetProp("PLAYER_INVENTORY", "ITEM_SPECIAL_ENERGY_PHASE_DISPLACEMENT", "f", 0)
 end
 function s040_area4.InitFromBlackboard()
-  Game.SetSceneGroupEnabledByName("sg_vignette_003", false)
   Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_001", true)
   Game.SetSceneGroupEnabledByName("sg_Hazardous_Puddle_002", true)
   if Blackboard.GetProp("s040_area4", "entity_LE_HazarousPool_001_enabled") == nil then

--- a/src/open_samus_returns_rando/files/levels/s090_area9.lua
+++ b/src/open_samus_returns_rando/files/levels/s090_area9.lua
@@ -113,7 +113,6 @@ function s090_area9.ElevatorSetTarget(_ARG_0_)
   end
 end
 function s090_area9.InitFromBlackboard()
-  Game.SetSceneGroupEnabledByName("sg_vignette_005", false)
   s090_area9.bAfterOmegasKilledMusicChange = false
   s090_area9.AllOmegasDeadCallback()
   s090_area9.OnFansInit()

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -314,6 +314,10 @@ def disable_vignettes(editor: PatcherEditor) -> None:
         "s040_area4": [
             {"block_group": 27, "cc": ["006"], "vignette_models": [46617345, 354988048]}
         ],
+        # Diggernaut Bomb Blocks
+        "s070_area7": [
+            {"block_group": 52, "cc": ["034"], "vignette_models": [1941338226]}
+        ],
         # Middle Save Station Water Bomb Blocks
         "s090_area9": [
             {"block_group": 66, "cc": ["007"], "vignette_models": [3224282959]}

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -336,14 +336,14 @@ def disable_vignettes(editor: PatcherEditor) -> None:
             bmssd = editor.get_file(f"maps/levels/c10_samus/{scenario_name}/{scenario_name}.bmssd", Bmssd)
             cc_group = bmssd.raw["unk_structs_b"]
             vignette_models = vignette_object["vignette_models"]
-            for camera in vignette_object["cc"]:
+            for camera in vignette_object["cc"]: # type: ignore
                 cc_name = "sg_SubArea_collision_camera_" + camera
                 for group in cc_group:
                     # Check for the cc_name
                     if group["str1"] == cc_name:
                         for model in group["struct3"][0]["struct5"]:
                             idx = group["struct3"][0]["struct5"].index(model)
-                            for vignette in vignette_models:
+                            for vignette in vignette_models: # type: ignore
                                 # Remove the model to prevent it from loading
                                 if model["int6"] == vignette:
                                     group["struct3"][0]["struct5"].pop(idx)

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -301,7 +301,7 @@ def patch_a1_teleporter_crumbles(editor: PatcherEditor) -> None:
 
 
 def disable_vignettes(editor: PatcherEditor) -> None:
-    scenario_block_sg = {
+    scenario_block_sg: dict[str, list[dict[str, typing.Any]]] = {
         # Exterior Alpha Bomb Block
         "s010_area1": [
             {"block_group": 6, "cc": ["017", "018"], "vignette_models": [2177967912]},
@@ -336,14 +336,14 @@ def disable_vignettes(editor: PatcherEditor) -> None:
             bmssd = editor.get_file(f"maps/levels/c10_samus/{scenario_name}/{scenario_name}.bmssd", Bmssd)
             cc_group = bmssd.raw["unk_structs_b"]
             vignette_models = vignette_object["vignette_models"]
-            for camera in vignette_object["cc"]: # type: ignore
+            for camera in vignette_object["cc"]:
                 cc_name = "sg_SubArea_collision_camera_" + camera
                 for group in cc_group:
                     # Check for the cc_name
                     if group["str1"] == cc_name:
                         for model in group["struct3"][0]["struct5"]:
                             idx = group["struct3"][0]["struct5"].index(model)
-                            for vignette in vignette_models: # type: ignore
+                            for vignette in vignette_models:
                                 # Remove the model to prevent it from loading
                                 if model["int6"] == vignette:
                                     group["struct3"][0]["struct5"].pop(idx)

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -2,7 +2,7 @@ import copy
 import typing
 
 from construct import Container, ListContainer
-from mercury_engine_data_structures.formats import Bmsad, Bmsbk, Bmscc, Bmtun
+from mercury_engine_data_structures.formats import Bmsad, Bmsbk, Bmscc, Bmssd, Bmtun
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 MULTI_ROOM_GAMMAS = [
@@ -303,21 +303,46 @@ def patch_a1_teleporter_crumbles(editor: PatcherEditor) -> None:
 def disable_vignettes(editor: PatcherEditor) -> None:
     scenario_block_sg = {
         # Exterior Alpha Bomb Block
-        "s010_area1": [6],
+        "s010_area1": [
+            {"block_group": 6, "cc": ["017", "018"], "vignette_models": [2177967912]},
+        ],
         # Beam Burst Shot Blocks
-        "s030_area3": [5],
+        "s030_area3": [
+            {"block_group": 5, "cc": ["036"], "vignette_models": [1239739760, 2986218869]},
+        ],
         # Lower Chozo Seal Bomb Blocks
-        "s040_area4": [27],
+        "s040_area4": [
+            {"block_group": 27, "cc": ["006"], "vignette_models": [46617345, 354988048]}
+        ],
         # Middle Save Station Water Bomb Blocks
-        "s090_area9": [66],
+        "s090_area9": [
+            {"block_group": 66, "cc": ["007"], "vignette_models": [3224282959]}
+        ],
     }
-    for scenario_name, block_groups in scenario_block_sg.items():
-        bmsbk = editor.get_file(f"maps/levels/c10_samus/{scenario_name}/{scenario_name}.bmsbk", Bmsbk)
-        for block_group in block_groups:
+    for scenario_name, vignette_objects in scenario_block_sg.items():
+        for vignette_object in vignette_objects:
+            block_group = vignette_object["block_group"]
+
+            bmsbk = editor.get_file(f"maps/levels/c10_samus/{scenario_name}/{scenario_name}.bmsbk", Bmsbk)
             blocks = bmsbk.raw["block_groups"][block_group]["types"][0]["blocks"]
             for block in range(len(blocks)):
                 # Separate the vignette from the block
                 blocks[block]["name2"] = ""
+
+            bmssd = editor.get_file(f"maps/levels/c10_samus/{scenario_name}/{scenario_name}.bmssd", Bmssd)
+            cc_group = bmssd.raw["unk_structs_b"]
+            vignette_models = vignette_object["vignette_models"]
+            for camera in vignette_object["cc"]:
+                cc_name = "sg_SubArea_collision_camera_" + camera
+                for group in cc_group:
+                    # Check for the cc_name
+                    if group["str1"] == cc_name:
+                        for model in group["struct3"][0]["struct5"]:
+                            idx = group["struct3"][0]["struct5"].index(model)
+                            for vignette in vignette_models:
+                                # Remove the model to prevent it from loading
+                                if model["int6"] == vignette:
+                                    group["struct3"][0]["struct5"].pop(idx)
 
 
 def apply_static_fixes(editor: PatcherEditor) -> None:

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -300,6 +300,26 @@ def patch_a1_teleporter_crumbles(editor: PatcherEditor) -> None:
     area1.raw["block_groups"][15]["types"][0]["blocks"][0]["respawn_time"] = 0.0
 
 
+def disable_vignettes(editor: PatcherEditor) -> None:
+    scenario_block_sg = {
+        # Exterior Alpha Bomb Block
+        "s010_area1": [6],
+        # Beam Burst Shot Blocks
+        "s030_area3": [5],
+        # Lower Chozo Seal Bomb Blocks
+        "s040_area4": [27],
+        # Middle Save Station Water Bomb Blocks
+        "s090_area9": [66],
+    }
+    for scenario_name, block_groups in scenario_block_sg.items():
+        bmsbk = editor.get_file(f"maps/levels/c10_samus/{scenario_name}/{scenario_name}.bmsbk", Bmsbk)
+        for block_group in block_groups:
+            blocks = bmsbk.raw["block_groups"][block_group]["types"][0]["blocks"]
+            for block in range(len(blocks)):
+                # Separate the vignette from the block
+                blocks[block]["name2"] = ""
+
+
 def apply_static_fixes(editor: PatcherEditor) -> None:
     patch_multi_room_gammas(editor)
     patch_pickup_rotation(editor)
@@ -313,3 +333,4 @@ def apply_static_fixes(editor: PatcherEditor) -> None:
     patch_area7_item(editor)
     patch_a4_collision(editor)
     patch_a1_teleporter_crumbles(editor)
+    disable_vignettes(editor)


### PR DESCRIPTION
Removes the references to the vignettes from the appropriate collision_cameras. Also removes the Diggernaut vignette in Area 6 for the start point by the door.

(We should probably go back and improve the parsing of the `bmssd` since it's pretty messy 😛 )

Fixes #393 