### PR TITLE
Re-enable SpecialEnergyCloud for powerups

### DIFF
--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -97,17 +97,31 @@ function RandomizerPowerup.MarkLocationCollected(actorOrName)
     Blackboard.SetProp(playerSection, propName, "b", true)
 end
 
+local AeionAbilityClouds = {
+    {"s000_surface", "LE_SpecialAbility_ScanningPulse"},
+    {"s028_area2c", "LE_SpecialAbility_EnergyShield"},
+    {"s030_area3", "LE_SpecialAbility_EnergyWave"},
+    {"s060_area6", "LE_SpecialAbility_PhaseDisplacement"},
+}
+
 function RandomizerPowerup.ActivateSpecialEnergy(actorOrName)
     local name = actorOrName.sName
-    local cloud = ""
-    if name ~= nil then
-        if string.sub(name, 0, 8) == "LE_Power" then
-            cloud = string.sub(name, 11)
-        -- SuperMissile actor name has a typo, so explicity set the value of cloud
-        elseif name == "LE_PoweUp_SuperMissile" then
-            cloud = "_SuperMissile"
+    local cloud = "TG_SpecialEnergyCloud"
+    local trigger = cloud .. string.sub(name, 11)
+
+    -- Powerups
+    if string.sub(name, 0, 8) == "LE_Power" and trigger ~= nil then
+        SpecialEnergyCloud.ActivateSpecialEnergy(trigger)
+    -- The Super Missile actor name has a typo, so explicity activate its cloud
+    elseif name == "LE_PoweUp_SuperMissile" then
+        SpecialEnergyCloud.ActivateSpecialEnergy(cloud .. "_SuperMissile")
+    end
+
+    -- Aeion abilities
+    for _, mapping in ipairs(AeionAbilityClouds) do
+        if mapping[1] == Scenario.CurrentScenarioID and mapping[2] == name then
+            SpecialEnergyCloud.ActivateSpecialEnergy(cloud)
         end
-        SpecialEnergyCloud.ActivateSpecialEnergy("TG_SpecialEnergyCloud" .. cloud)
     end
 end
 

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -51,7 +51,7 @@ function RandomizerPowerup.OnPickedUp(resources, actorOrName)
 
     Scenario.UpdateProgressiveItemModels()
     if actorOrName ~= nil then
-        RandomizerPowerup.GetActorName(actorOrName)
+        RandomizerPowerup.CheckActorOrName(actorOrName)
     end
     RandomizerPowerup.IncrementInventoryIndex()
     RL.UpdateRDVClient(false)
@@ -71,7 +71,7 @@ function RandomizerPowerup.PropertyForLocation(actorOrName)
     return "c_" .. actorOrName
 end
 
-function RandomizerPowerup.GetActorName(actorOrName)
+function RandomizerPowerup.CheckActorOrName(actorOrName)
     local name
     -- normal pickups
     if actorOrName.sName ~= nil then
@@ -111,10 +111,8 @@ function RandomizerPowerup.ActivateSpecialEnergy(name)
         if Game.GetEntity(trigger) ~= nil then
             SpecialEnergyCloud.ActivateSpecialEnergy(trigger)
         end
-    end
-
-    -- Aeion abilities
-    if string.sub(name, 0, 17) == "LE_SpecialAbility" and Game.GetEntity(name) ~= nil then
+    else
+        -- Aeion abilities
         SpecialEnergyCloud.ActivateSpecialEnergy(cloud)
     end
 end

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -97,29 +97,22 @@ function RandomizerPowerup.MarkLocationCollected(actorOrName)
     Blackboard.SetProp(playerSection, propName, "b", true)
 end
 
-local AeionAbilityClouds = {
-    {"s000_surface", "LE_SpecialAbility_ScanningPulse"},
-    {"s028_area2c", "LE_SpecialAbility_EnergyShield"},
-    {"s030_area3", "LE_SpecialAbility_EnergyWave"},
-    {"s060_area6", "LE_SpecialAbility_PhaseDisplacement"},
-}
-
 function RandomizerPowerup.ActivateSpecialEnergy(actorOrName)
     local name = actorOrName.sName
     local cloud = "TG_SpecialEnergyCloud"
-    local trigger = cloud .. string.sub(name, 11)
 
     -- Powerups
-    if string.sub(name, 0, 8) == "LE_Power" and trigger ~= nil then
-        SpecialEnergyCloud.ActivateSpecialEnergy(trigger)
-    -- The Super Missile actor name has a typo, so explicity activate its cloud
-    elseif name == "LE_PoweUp_SuperMissile" then
-        SpecialEnergyCloud.ActivateSpecialEnergy(cloud .. "_SuperMissile")
+    if string.sub(name, 0, 7) == "LE_Powe" then
+        local powerup = string.find(name, "_", 4)
+        local trigger = cloud .. string.sub(name, powerup)
+        if Game.GetEntity(trigger) ~= nil then
+            SpecialEnergyCloud.ActivateSpecialEnergy(trigger)
+        end
     end
 
     -- Aeion abilities
-    for _, mapping in ipairs(AeionAbilityClouds) do
-        if mapping[1] == Scenario.CurrentScenarioID and mapping[2] == name then
+    if string.sub(name, 0, 17) == "LE_SpecialAbility" then
+        if Game.GetEntity(name) ~= nil then
             SpecialEnergyCloud.ActivateSpecialEnergy(cloud)
         end
     end

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -114,10 +114,8 @@ function RandomizerPowerup.ActivateSpecialEnergy(name)
     end
 
     -- Aeion abilities
-    if string.sub(name, 0, 17) == "LE_SpecialAbility" then
-        if Game.GetEntity(name) ~= nil then
-            SpecialEnergyCloud.ActivateSpecialEnergy(cloud)
-        end
+    if string.sub(name, 0, 17) == "LE_SpecialAbility" and Game.GetEntity(name) ~= nil then
+        SpecialEnergyCloud.ActivateSpecialEnergy(cloud)
     end
 end
 

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -111,8 +111,8 @@ function RandomizerPowerup.ActivateSpecialEnergy(name)
         if Game.GetEntity(trigger) ~= nil then
             SpecialEnergyCloud.ActivateSpecialEnergy(trigger)
         end
-    else
-        -- Aeion abilities
+    -- Aeion abilities
+    elseif string.sub(name, 0, 17) == "LE_SpecialAbility" then
         SpecialEnergyCloud.ActivateSpecialEnergy(cloud)
     end
 end

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -51,8 +51,7 @@ function RandomizerPowerup.OnPickedUp(resources, actorOrName)
 
     Scenario.UpdateProgressiveItemModels()
     if actorOrName ~= nil then
-        RandomizerPowerup.ActivateSpecialEnergy(actorOrName)
-        RandomizerPowerup.MarkLocationCollected(actorOrName)
+        RandomizerPowerup.GetActorName(actorOrName)
     end
     RandomizerPowerup.IncrementInventoryIndex()
     RL.UpdateRDVClient(false)
@@ -72,7 +71,7 @@ function RandomizerPowerup.PropertyForLocation(actorOrName)
     return "c_" .. actorOrName
 end
 
-function RandomizerPowerup.MarkLocationCollected(actorOrName)
+function RandomizerPowerup.GetActorName(actorOrName)
     local name
     -- normal pickups
     if actorOrName.sName ~= nil then
@@ -85,6 +84,11 @@ function RandomizerPowerup.MarkLocationCollected(actorOrName)
     if name == nil then
         return
     end
+    RandomizerPowerup.MarkLocationCollected(name)
+    RandomizerPowerup.ActivateSpecialEnergy(name)
+end
+
+function RandomizerPowerup.MarkLocationCollected(name)
     local playerSection = Game.GetPlayerBlackboardSectionName()
     local currentScenario = Scenario.CurrentScenarioID
     local propScenario = currentScenario
@@ -97,8 +101,7 @@ function RandomizerPowerup.MarkLocationCollected(actorOrName)
     Blackboard.SetProp(playerSection, propName, "b", true)
 end
 
-function RandomizerPowerup.ActivateSpecialEnergy(actorOrName)
-    local name = actorOrName.sName
+function RandomizerPowerup.ActivateSpecialEnergy(name)
     local cloud = "TG_SpecialEnergyCloud"
 
     -- Powerups

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -51,6 +51,7 @@ function RandomizerPowerup.OnPickedUp(resources, actorOrName)
 
     Scenario.UpdateProgressiveItemModels()
     if actorOrName ~= nil then
+        RandomizerPowerup.ActivateSpecialEnergy(actorOrName)
         RandomizerPowerup.MarkLocationCollected(actorOrName)
     end
     RandomizerPowerup.IncrementInventoryIndex()
@@ -94,6 +95,20 @@ function RandomizerPowerup.MarkLocationCollected(actorOrName)
 
     local propName = RandomizerPowerup.PropertyForLocation(string.format("%s_%s", propScenario, name))
     Blackboard.SetProp(playerSection, propName, "b", true)
+end
+
+function RandomizerPowerup.ActivateSpecialEnergy(actorOrName)
+    local name = actorOrName.sName
+    local cloud = ""
+    if name ~= nil then
+        if string.sub(name, 0, 8) == "LE_Power" then
+            cloud = string.sub(name, 11)
+        -- SuperMissile actor name has a typo, so explicity set the value of cloud
+        elseif name == "LE_PoweUp_SuperMissile" then
+            cloud = "_SuperMissile"
+        end
+        SpecialEnergyCloud.ActivateSpecialEnergy("TG_SpecialEnergyCloud" .. cloud)
+    end
 end
 
 function RandomizerPowerup.ObjectiveComplete()

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -51,7 +51,7 @@ function RandomizerPowerup.OnPickedUp(resources, actorOrName)
 
     Scenario.UpdateProgressiveItemModels()
     if actorOrName ~= nil then
-        RandomizerPowerup.CheckActorOrName(actorOrName)
+        RandomizerPowerup.PostCollectionAdjustments(actorOrName)
     end
     RandomizerPowerup.IncrementInventoryIndex()
     RL.UpdateRDVClient(false)
@@ -71,7 +71,7 @@ function RandomizerPowerup.PropertyForLocation(actorOrName)
     return "c_" .. actorOrName
 end
 
-function RandomizerPowerup.CheckActorOrName(actorOrName)
+function RandomizerPowerup.PostCollectionAdjustments(actorOrName)
     local name
     -- normal pickups
     if actorOrName.sName ~= nil then


### PR DESCRIPTION
Re-enables the `SpecialEnergyCloud` for each powerup in a Chozo or Aeion Statue. Special handling was needed for Super Missiles and the Aeion Abilities due to naming issues.

Fixes #104 