### PR TITLE
Increment Metroid count if going through A8 Backwards

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/src/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -210,6 +210,10 @@ end
 function s100_area10.OnMetroidDead()
   -- Disable the intro and the camera change triggers if a Metroid has been defeated, which means that Reverse Area 8 should be enabled
   Game.DisableTrigger("TG_Intro_Larva")
+  -- If going backwards, increment the Metroid counter on the first Metroid death only
+  if Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") == 1 and s100_area10.iMetroidTotalCountIncrements == 0 then
+    Game.AddSF(0.15, "s100_area10.IncrementMetroidTotalCount", "")
+  end
   if Game.GetEntity("TG_ChangeCamera_IntroLarva") ~= nil then
     Game.GetEntity("TG_ChangeCamera_IntroLarva").TRIGGER:DisableTrigger()
   end


### PR DESCRIPTION
If going backwards through Area 8, increment the Metroid counter on the first Metroid death only as if the cutscene was watched. This does not get called if going forwards with the cutscene active.

https://github.com/randovania/open-samus-returns-rando/assets/38679103/a38cd95c-00b6-452e-b58b-cbec9839226a

Fixes #404 