### PR TITLE
Disable low poly Samus if reloading from checkpoint during boss fight

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s070_area7.lua
+++ b/src/open_samus_returns_rando/files/levels/s070_area7.lua
@@ -108,6 +108,7 @@ end
 function s070_area7.OnReloaded()
 end
 function s070_area7.OnExit()
+  s070_area7.SetLowModelsVisibility(false)
 end
 function s070_area7.OnEnter_ActivationDNA_001()
   -- Game.OnDNAMechApproached("LE_ChozoUnlockAreaDNA_001", 1)

--- a/src/open_samus_returns_rando/files/levels/s070_area7.lua
+++ b/src/open_samus_returns_rando/files/levels/s070_area7.lua
@@ -93,6 +93,7 @@ s070_area7.tDNAScanLandmarks = {
 function s070_area7.InitFromBlackboard()
   Game.SetSubAreaCurrentSetup("collision_camera_037", "Omega_Enabled", true)
   Scenario.WriteToBlackboard("OmegaDiscovered", "b", true)
+  s070_area7.SetLowModelsVisibility(false)
   if Blackboard.GetProp("s070_area7", "entity_LE_HazarousPool_001_enabled") == nil then
     Game.GetEntity("LE_HazarousPool_001").HAZAROUSPOOL:Activate(true)
     Game.GetEntity("LE_HazarousPool_002").HAZAROUSPOOL:Activate(false)

--- a/src/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/src/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -101,6 +101,7 @@ end
 function s100_area10.OnReloaded()
 end
 function s100_area10.OnExit()
+  s070_area7.SetLowModelsVisibility(false)
 end
 function s100_area10.OnEnter_ActivationTeleport_10_01()
   Game.OnTeleportApproached("LE_Teleporter_10_01")

--- a/src/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/src/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -101,7 +101,7 @@ end
 function s100_area10.OnReloaded()
 end
 function s100_area10.OnExit()
-  s070_area7.SetLowModelsVisibility(false)
+  s100_area10.SetLowModelsVisibility(false)
 end
 function s100_area10.OnEnter_ActivationTeleport_10_01()
   Game.OnTeleportApproached("LE_Teleporter_10_01")

--- a/src/open_samus_returns_rando/files/levels/s100_area10.lua
+++ b/src/open_samus_returns_rando/files/levels/s100_area10.lua
@@ -77,6 +77,7 @@ function s100_area10.InitFromBlackboard()
   Game.DisableEntity("LE_Baby_Hatchling")
   Game.DisableTrigger("TG_MetroidRadar")
   Game.GetEntity("LE_RandoDNA").USABLE:Activate(false)
+  s100_area10.SetLowModelsVisibility(false)
   if Game.GetEntity("LE_ValveQueen") ~= nil then
     if Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") ~= nil and s100_area10.iNumMetroids == Blackboard.GetProp("DEFEATED_ENEMIES", "Metroid") then
       Game.GetEntity("LE_ValveQueen").MODELUPDATER:SetMeshVisible("Valve", false)

--- a/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
+++ b/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
@@ -60,6 +60,7 @@ function s110_surfaceb.ElevatorSetTarget(_ARG_0_)
   GUI.ElevatorSetTarget("s000_surface_elevator", false)
 end
 function s110_surfaceb.InitFromBlackboard()
+  s110_surfaceb.SetLowModelsVisibility(false)
 end
 function s110_surfaceb.OnReloaded()
 end

--- a/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
+++ b/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
@@ -86,6 +86,7 @@ function s110_surfaceb.InitializeRidleyStorms()
   end
 end
 function s110_surfaceb.OnExit()
+  s070_area7.SetLowModelsVisibility(false)
 end
 function s110_surfaceb.RecoverEnergy()
   if Game.GetPlayer() ~= nil then

--- a/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
+++ b/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
@@ -86,7 +86,7 @@ function s110_surfaceb.InitializeRidleyStorms()
   end
 end
 function s110_surfaceb.OnExit()
-  s070_area7.SetLowModelsVisibility(false)
+  s110_surfaceb.SetLowModelsVisibility(false)
 end
 function s110_surfaceb.RecoverEnergy()
   if Game.GetPlayer() ~= nil then


### PR DESCRIPTION
`OnPlayerDead` already handles disabling the low poly on death, but reloading from checkpoint while in a boss fight is not handled in vanilla. This ensures low poly is disabled when a scenario load happens.

Fixes #317 