### PR TITLE
Surface West Music Changes

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
+++ b/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
@@ -61,6 +61,9 @@ function s110_surfaceb.ElevatorSetTarget(_ARG_0_)
 end
 function s110_surfaceb.InitFromBlackboard()
   s110_surfaceb.SetLowModelsVisibility(false)
+  if Game.GetItemAmount(Game.GetPlayerName(), "ITEM_ADN") < 39 and Game.GetItemAmount(Game.GetPlayerName(), "ITEM_BABY_HATCHLING") < 1 then
+    Game.PlayMusicStream(0, "streams/music/t_m2_surface_arr1.wav", -1, -1, -1, 2, 2, 1)
+end
 end
 function s110_surfaceb.OnReloaded()
 end

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -129,7 +129,10 @@ function RandomizerPowerup.ObjectiveComplete()
         })
         if baby > 0 then
             GUI.LaunchMessage("All Metroid DNA has been collected!\nThe path to Proteus Ridley has been opened in Surface West!",
-                "RandomizerPowerup.Dummy", "")
+            "RandomizerPowerup.Dummy", "")
+            if Scenario.CurrentScenarioID == "s110_surfaceb" then
+                Game.PlayMusicStream(0, "streams/music/k_crateria99.wav", -1, -1, -1, 2, 2, 1)
+            end
         elseif baby == 0 then
             GUI.LaunchMessage("All Metroid DNA has been collected!\n" .. Init.sBabyMetroidHint,
                 "RandomizerPowerup.Dummy", "")


### PR DESCRIPTION
Update the music in Surface West to be Surface East 1 if DNA is not 39 and Baby is not collected, and then uses the regular theme once the conditions to access Ridley are met. The reason for doing this is to add yet another indicator if the seed can be finished.

Debated on doing the 2nd Surface theme to indicate its a later area, but I think the first theme fits better since Landing Site uses that theme.