### PR TITLE
Support shuffling block types

### DIFF
--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -824,6 +824,7 @@
                 "super_missile",
                 "bomb",
                 "power_bomb",
+                "screw_attack",
                 "baby",
                 "weight"
             ]

--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -214,6 +214,16 @@
             },
             "default": []
         },
+        "block_patches": {
+            "type": "object",
+            "patternProperties": {
+                ".*": {
+                    "type": "object",
+                    "$ref": "#/$defs/block_types"
+                }
+            },
+            "default": {}
+        },
         "energy_per_tank": {
             "description": "How much energy collecting an Energy Tank gives",
             "type": "number",
@@ -804,6 +814,18 @@
                 "t_matad_ambi06",
                 "t_matad_area01_damage",
                 "tank_jingle"
+            ]
+        },
+        "block_types": {
+            "type": "string",
+            "enum": [
+                "power_beam",
+                "missile",
+                "super_missile",
+                "bomb",
+                "power_bomb",
+                "baby",
+                "weight"
             ]
         }
     }

--- a/src/open_samus_returns_rando/misc_patches/block_patches.py
+++ b/src/open_samus_returns_rando/misc_patches/block_patches.py
@@ -12,10 +12,8 @@ def patch_block_types(editor: PatcherEditor, configuration: dict) -> None:
         blocks = bmsbk.raw["block_groups"]
         for block in blocks:
             block_type = block["types"][0]
-            temp_type: str = ""
             for original_type, new_type in configuration["block_patches"].items():
                 # Check for the block type and change it to the new type
-                if original_type == block_type["block_type"] and temp_type == "":
-                    # Set the temp_type to the original_type to ensure the block doesnt get changed again
-                    temp_type = original_type
+                if original_type == block_type["block_type"]:
                     block_type["block_type"] = new_type
+                    break

--- a/src/open_samus_returns_rando/misc_patches/block_patches.py
+++ b/src/open_samus_returns_rando/misc_patches/block_patches.py
@@ -1,0 +1,21 @@
+from mercury_engine_data_structures.formats import Bmsbk
+from open_samus_returns_rando.constants import ALL_SCENARIOS
+from open_samus_returns_rando.patcher_editor import PatcherEditor
+
+
+def patch_block_types(editor: PatcherEditor, configuration: dict) -> None:
+    if len(configuration["block_patches"]) == 0:
+        return
+
+    for scenario_name in ALL_SCENARIOS:
+        bmsbk = editor.get_file(f"maps/levels/c10_samus/{scenario_name}/{scenario_name}.bmsbk", Bmsbk)
+        blocks = bmsbk.raw["block_groups"]
+        for block in blocks:
+            block_type = block["types"][0]
+            temp_type: str = ""
+            for original_type, new_type in configuration["block_patches"].items():
+                # Check for the block type and change it to the new type
+                if original_type == block_type["block_type"] and temp_type == "":
+                    # Set the temp_type to the original_type to ensure the block doesnt get changed again
+                    temp_type = original_type
+                    block_type["block_type"] = new_type

--- a/src/open_samus_returns_rando/samus_returns_patcher.py
+++ b/src/open_samus_returns_rando/samus_returns_patcher.py
@@ -9,6 +9,7 @@ from open_samus_returns_rando.debug import debug_custom_pickups, debug_spawn_poi
 from open_samus_returns_rando.files import files_path
 from open_samus_returns_rando.logger import LOG
 from open_samus_returns_rando.lua_editor import LuaEditor
+from open_samus_returns_rando.misc_patches.block_patches import patch_block_types
 from open_samus_returns_rando.misc_patches.collision_camera_table import create_collision_camera_table
 from open_samus_returns_rando.misc_patches.credits import patch_credits
 from open_samus_returns_rando.misc_patches.elevators import patch_elevators
@@ -127,6 +128,9 @@ def patch_extracted(input_path: Path, input_exheader: Path | None, output_path: 
 
     # Patch elevator destinations
     patch_elevators(editor, configuration)
+
+    # Patch blocks to another type
+    patch_block_types(editor, configuration)
 
     out_exefs = output_path.joinpath("exefs")
     out_romfs = output_path.joinpath("romfs")


### PR DESCRIPTION
Changes all the blocks of a certain type to another type. Note that will be a chaos option in Randovania, so it will not be logical, but the groundwork for it is there if that ever happens.

Relevant to #409 