### PR TITLE
Add toggle for tanks fully refilling ammo

### DIFF
--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -307,6 +307,11 @@
                     "type": "boolean",
                     "description": "Removes the wall between the Queen and Baby, allowing access into Area 8 from Surface West.",
                     "default": false
+                },
+                "tanks_refill_ammo": {
+                    "type": "boolean",
+                    "description": "If enabled, collecting a tank refills that ammo to max capacity. In vanilla, only Energy and Aeion get fully refilled to max capacity.",
+                    "default": true
                 }
             },
             "additionalProperties": false

--- a/src/open_samus_returns_rando/files/templates/custom_init.lua
+++ b/src/open_samus_returns_rando/files/templates/custom_init.lua
@@ -33,6 +33,7 @@ Init.sThisRandoIdentifier = TEMPLATE("configuration_identifier") .. Init.sLayout
 Init.tBoxesSeen = 0
 Init.bEnableRoomIds = TEMPLATE("enable_room_ids")
 Init.sBabyMetroidHint = TEMPLATE("baby_metroid_hint")
+Init.bTanksRefillAmmo = TEMPLATE("tanks_refill_ammo")
 
 local orig_log = Game.LogWarn
 if TEMPLATE("enable_remote_lua") then

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -28,17 +28,21 @@ function RandomizerPowerup.IncreaseItemAmount(item_id, quantity, capacity)
     target = math.max(target, 0)
     RandomizerPowerup.SetItemAmount(item_id, target)
 
-    local itemAmount = Game.GetPlayer().INVENTORY
     if item_id == "ITEM_CURRENT_SPECIAL_ENERGY" then
         local specialEnergy = Game.GetPlayer().SPECIALENERGY
         specialEnergy.fMaxEnergy = capacity
         specialEnergy.fEnergy = capacity
-    elseif item_id == "ITEM_WEAPON_MISSILE_CURRENT" then
-        itemAmount:SetItemAmount(item_id, capacity)
-    elseif item_id == "ITEM_WEAPON_SUPER_MISSILE_CURRENT" then
-        itemAmount:SetItemAmount(item_id, capacity)
-    elseif item_id == "ITEM_WEAPON_POWER_BOMB_CURRENT" then
-        itemAmount:SetItemAmount(item_id, capacity)
+    end
+
+    if Init.bTanksRefillAmmo then
+        local tank = Game.GetPlayer().INVENTORY
+        if item_id == "ITEM_WEAPON_MISSILE_CURRENT" then
+            tank:SetItemAmount(item_id, capacity)
+        elseif item_id == "ITEM_WEAPON_SUPER_MISSILE_CURRENT" then
+            tank:SetItemAmount(item_id, capacity)
+        elseif item_id == "ITEM_WEAPON_POWER_BOMB_CURRENT" then
+            tank:SetItemAmount(item_id, capacity)
+        end
     end
 end
 

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -198,6 +198,7 @@ class LuaEditor:
 
     def _create_custom_init(self, editor: PatcherEditor, configuration: dict) -> str:
         cosmetic_options: dict = configuration["cosmetic_patches"]
+        game_patches: dict = configuration["game_patches"]
         inventory: dict[str, int] = configuration["starting_items"]
         starting_location: dict = configuration["starting_location"]
         starting_text: list[str] = configuration.get("starting_text", [])
@@ -273,7 +274,8 @@ class LuaEditor:
             "enable_room_ids": False if cosmetic_options["enable_room_name_display"] == "NEVER" else True,
             "layout_uuid": layout_uuid,
             "enable_remote_lua": enable_remote_lua,
-            "baby_metroid_hint": baby_metroid_hint
+            "baby_metroid_hint": baby_metroid_hint,
+            "tanks_refill_ammo": True if game_patches["tanks_refill_ammo"] else False
         }
 
         return lua_util.replace_lua_template("custom_init.lua", replacement)

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -197,11 +197,11 @@ class LuaEditor:
         self._progressive_models += models
 
     def _create_custom_init(self, editor: PatcherEditor, configuration: dict) -> str:
-        cosmetic_options: dict = configuration["cosmetic_patches"]
-        game_patches: dict = configuration["game_patches"]
         inventory: dict[str, int] = configuration["starting_items"]
         starting_location: dict = configuration["starting_location"]
         starting_text: list[str] = configuration.get("starting_text", [])
+        game_patches: dict = configuration["game_patches"]
+        cosmetic_options: dict = configuration["cosmetic_patches"]
         configuration_identifier: str = configuration["configuration_identifier"]
         enable_remote_lua: bool = configuration.get("enable_remote_lua", False)
 
@@ -275,7 +275,7 @@ class LuaEditor:
             "layout_uuid": layout_uuid,
             "enable_remote_lua": enable_remote_lua,
             "baby_metroid_hint": baby_metroid_hint,
-            "tanks_refill_ammo": True if game_patches["tanks_refill_ammo"] else False
+            "tanks_refill_ammo": game_patches["tanks_refill_ammo"]
         }
 
         return lua_util.replace_lua_template("custom_init.lua", replacement)


### PR DESCRIPTION
Finally adding an option so it can be toggled off if desired for whatever reason. Leaving the default to on since that's been the behavior for a long time and too late to change at this point.

Fixes #313 