### PR TITLE
Revert caching `get_asset_names_in_folder`

### DIFF
--- a/src/open_samus_returns_rando/patcher_editor.py
+++ b/src/open_samus_returns_rando/patcher_editor.py
@@ -1,5 +1,4 @@
 import copy
-import functools
 import typing
 from pathlib import Path
 
@@ -75,7 +74,6 @@ class PatcherEditor(FileTreeEditor):
         scenario.raw.actors[layer].pop(actor_name)
         scenario.remove_actor_from_all_groups(actor_name)
 
-    @functools.cache
     def get_asset_names_in_folder(self, folder: str) -> typing.Iterator[str]:
         yield from (
             name


### PR DESCRIPTION
The caching causing memory errors in scenarios without a Chozo Seal present, where a custom DNA Seal has been added. This has a side effect of the patcher being ~1-2 seconds slower than before.

Related to #435 