### PR TITLE
Readd cache

### DIFF
--- a/src/open_samus_returns_rando/patcher_editor.py
+++ b/src/open_samus_returns_rando/patcher_editor.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import typing
 from pathlib import Path
 
@@ -74,10 +75,10 @@ class PatcherEditor(FileTreeEditor):
         scenario.raw.actors[layer].pop(actor_name)
         scenario.remove_actor_from_all_groups(actor_name)
 
-    def get_asset_names_in_folder(self, folder: str) -> typing.Iterator[str]:
-        yield from (
-            name
+    @functools.cache
+    def get_asset_names_in_folder(self, folder: str) -> list[str]:
+        return [name
             for name in self._name_for_asset_id.values()
             if name.startswith(folder) and self.does_asset_exists(name)
-        )
+        ]
 


### PR DESCRIPTION
Ok, I lied in the other PR. I just looked into the code. We return a generator via `yield` in the function.
It's a pretty bad idea to use a `cache` on a generator because it will return the same generator multiple times but we iterate through it, so the generator is already exhausted after first loop.
Or short: This code is only executed once and not for all required scenarios.
```
    for asset in editor.get_asset_names_in_folder("actors/props/systemmechdna"):
        editor.ensure_present_in_scenario(scenario_name, asset)
```

I switched to return a list instead.
Should have seen this when I initially reviewed it. Stupid me, sorry. :(

But better to not include for the next release.

Fix #435