### PR TITLE
2nd Attempt at fixing `required_dna` compatibility

### DIFF
--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -258,8 +258,7 @@
         "required_dna": {
             "description": "The amount of Metroid DNA required to access Proteus Ridley.",
             "type": "integer",
-            "minimum": 0,
-            "default": 39
+            "minimum": 0
         },
         "reveal_map_on_start": {
             "type": "boolean",

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -264,7 +264,7 @@ class LuaEditor:
         if "required_dna" in configuration:
             required_dna = configuration["required_dna"]
         else:
-            starting_dna = [item for item in final_inventory if item.startswith("ITEM_RANDO_DNA")]
+            starting_dna = [item for item in inventory if item.startswith("ITEM_RANDO_DNA")]
             required_dna = 39 - len(starting_dna)
 
         replacement = {

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -261,6 +261,12 @@ class LuaEditor:
         if "baby_metroid_hint" in configuration:
             baby_metroid_hint = lua_util.wrap_string(configuration["baby_metroid_hint"])
 
+        if "required_dna" in configuration:
+            required_dna = configuration["required_dna"]
+        else:
+            starting_dna = [item for item in final_inventory if item.startswith("ITEM_RANDO_DNA")]
+            required_dna = 39 - len(starting_dna)
+
         replacement = {
             "new_game_inventory": final_inventory,
             "starting_scenario": lua_util.wrap_string(starting_location["scenario"]),
@@ -276,7 +282,7 @@ class LuaEditor:
             "enable_remote_lua": enable_remote_lua,
             "baby_metroid_hint": baby_metroid_hint,
             "tanks_refill_ammo": game_patches["tanks_refill_ammo"],
-            "required_dna": configuration["required_dna"]
+            "required_dna": required_dna
         }
 
         return lua_util.replace_lua_template("custom_init.lua", replacement)


### PR DESCRIPTION
Reworks how `required_dna` is handled to ensure all patcher jsons are compatible.

- Removes the default value from the schema
- Checks for the new configuration field in the json
  - If it exists, set the value of `required_dna` to it (new jsons)
  - If it doesn't exist, take the difference of 39 and the starting DNA to calculate the required DNA (old jsons) 