### PR TITLE
Support custom Baby size

### DIFF
--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -590,6 +590,25 @@
             },
             "default": {}
         },
+        "actor_attributes": {
+            "description": "Modifications to actor attributes.",
+            "type": "object",
+            "properties": {
+                "babyhatchling": {
+                    "properties": {
+                        "size": {
+                            "description": "Size of the Baby Metroid.",
+                            "type": "number",
+                            "minimum": 0.1,
+                            "maximum": 10,
+                            "default": 0.6600000262260437
+                        }
+                    },
+                    "default": {}
+                }
+            },
+            "default": {}
+        },
         "configuration_identifier": {
             "type": "string",
             "description": "An unique identifier for this configuration. Only save files created with this identifier can be loaded."

--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -596,7 +596,7 @@
             "properties": {
                 "babyhatchling": {
                     "properties": {
-                        "size": {
+                        "model_scale": {
                             "description": "Size of the Baby Metroid.",
                             "type": "number",
                             "minimum": 0.1,

--- a/src/open_samus_returns_rando/misc_patches/actor_attributes.py
+++ b/src/open_samus_returns_rando/misc_patches/actor_attributes.py
@@ -8,4 +8,4 @@ def patch_actor_attributes(editor: PatcherEditor, configuration: dict) -> None:
 
 def _custom_baby_size(editor: PatcherEditor, configuration: dict) -> None:
     baby = editor.get_file("actors/characters/babyhatchling/charclasses/babyhatchling.bmsad", Bmsad)
-    baby.raw["header"]["model_scale"] = configuration["babyhatchling"]["size"]
+    baby.raw["header"]["model_scale"] = configuration["babyhatchling"]["model_scale"]

--- a/src/open_samus_returns_rando/misc_patches/actor_attributes.py
+++ b/src/open_samus_returns_rando/misc_patches/actor_attributes.py
@@ -1,0 +1,11 @@
+from mercury_engine_data_structures.formats import Bmsad
+from open_samus_returns_rando.patcher_editor import PatcherEditor
+
+
+def patch_actor_attributes(editor: PatcherEditor, configuration: dict) -> None:
+    _custom_baby_size(editor, configuration)
+
+
+def _custom_baby_size(editor: PatcherEditor, configuration: dict) -> None:
+    baby = editor.get_file("actors/characters/babyhatchling/charclasses/babyhatchling.bmsad", Bmsad)
+    baby.raw["header"]["model_scale"] = configuration["babyhatchling"]["size"]

--- a/src/open_samus_returns_rando/samus_returns_patcher.py
+++ b/src/open_samus_returns_rando/samus_returns_patcher.py
@@ -9,6 +9,7 @@ from open_samus_returns_rando.debug import debug_custom_pickups, debug_spawn_poi
 from open_samus_returns_rando.files import files_path
 from open_samus_returns_rando.logger import LOG
 from open_samus_returns_rando.lua_editor import LuaEditor
+from open_samus_returns_rando.misc_patches.actor_attributes import patch_actor_attributes
 from open_samus_returns_rando.misc_patches.block_patches import patch_block_types
 from open_samus_returns_rando.misc_patches.collision_camera_table import create_collision_camera_table
 from open_samus_returns_rando.misc_patches.credits import patch_credits
@@ -136,6 +137,9 @@ def patch_extracted(input_path: Path, input_exheader: Path | None, output_path: 
 
     # Patch blocks to another type
     patch_block_types(editor, configuration)
+
+    # Patch actor attributes
+    patch_actor_attributes(editor, configuration["actor_attributes"])
 
     out_exefs = output_path.joinpath("exefs")
     out_romfs = output_path.joinpath("romfs")


### PR DESCRIPTION
This PR allows for modifying actor bmsad's via the schema. Currently, changing the `model_scale` of the Baby is supported. We could move other changes we make to actors here as well, but I believe the current changes we make are static changes and never planned to be modified. I'm unsure if this should be more generalized or not or if it could be improved in anyway to be more customizable for rdv/plando purposes.

`model_scale` of 10
![image](https://github.com/user-attachments/assets/df72819e-4c02-47e5-892a-581b2ef63717)

`model_scale` of 0.1
![image](https://github.com/user-attachments/assets/1cc8e81f-c9bc-4271-aec0-a8d83fea3d10)

Related to #409 