### PR TITLE
Ruff update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.7
+    rev: v0.6.1
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix  ]

--- a/src/open_samus_returns_rando/misc_patches/actor_attributes.py
+++ b/src/open_samus_returns_rando/misc_patches/actor_attributes.py
@@ -1,4 +1,5 @@
 from mercury_engine_data_structures.formats import Bmsad
+
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 

--- a/src/open_samus_returns_rando/misc_patches/block_patches.py
+++ b/src/open_samus_returns_rando/misc_patches/block_patches.py
@@ -1,4 +1,5 @@
 from mercury_engine_data_structures.formats import Bmsbk
+
 from open_samus_returns_rando.constants import ALL_SCENARIOS
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 

--- a/src/open_samus_returns_rando/misc_patches/collision_camera_table.py
+++ b/src/open_samus_returns_rando/misc_patches/collision_camera_table.py
@@ -1,5 +1,6 @@
 from construct import Container  # type: ignore[import-untyped]
 from mercury_engine_data_structures.formats.lua import Lua
+
 from open_samus_returns_rando.misc_patches import lua_util
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 

--- a/src/open_samus_returns_rando/misc_patches/credits.py
+++ b/src/open_samus_returns_rando/misc_patches/credits.py
@@ -2,6 +2,7 @@
 import re
 
 from mercury_engine_data_structures.formats import Txt
+
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 _PROJECT_MEMBERS = {

--- a/src/open_samus_returns_rando/misc_patches/elevators.py
+++ b/src/open_samus_returns_rando/misc_patches/elevators.py
@@ -1,5 +1,6 @@
 from construct import Container  # type: ignore[import-untyped]
 from mercury_engine_data_structures.formats.lua import Lua
+
 from open_samus_returns_rando.misc_patches import lua_util
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 

--- a/src/open_samus_returns_rando/misc_patches/final_boss.py
+++ b/src/open_samus_returns_rando/misc_patches/final_boss.py
@@ -2,6 +2,7 @@ import typing
 
 from construct import Container  # type: ignore[import-untyped]
 from mercury_engine_data_structures.formats import Bmsad, Bmtun
+
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 

--- a/src/open_samus_returns_rando/misc_patches/lua_util.py
+++ b/src/open_samus_returns_rando/misc_patches/lua_util.py
@@ -4,6 +4,7 @@ import typing
 from construct import Container  # type: ignore[import-untyped]
 from mercury_engine_data_structures.file_tree_editor import FileTreeEditor
 from mercury_engine_data_structures.formats.lua import Lua
+
 from open_samus_returns_rando.files import files_path, templates_path
 
 

--- a/src/open_samus_returns_rando/pickups/custom_pickups.py
+++ b/src/open_samus_returns_rando/pickups/custom_pickups.py
@@ -2,6 +2,7 @@ import typing
 
 from construct import Container, ListContainer  # type: ignore[import-untyped]
 from mercury_engine_data_structures.formats import Bmsmsd
+
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 

--- a/src/open_samus_returns_rando/pickups/pickup.py
+++ b/src/open_samus_returns_rando/pickups/pickup.py
@@ -6,6 +6,7 @@ from enum import Enum
 from construct import Container, ListContainer  # type: ignore[import-untyped]
 from mercury_engine_data_structures.formats import Bmsad, Bmsmsd, Lua
 from mercury_engine_data_structures.formats.bmsmsd import TileType
+
 from open_samus_returns_rando.constants import get_package_name
 from open_samus_returns_rando.files import templates_path
 from open_samus_returns_rando.logger import LOG

--- a/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/chozo_seal_patches.py
@@ -2,6 +2,7 @@ import typing
 
 from construct import Container, ListContainer  # type: ignore[import-untyped]
 from mercury_engine_data_structures.formats import Bmsad, Bmsmsd
+
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 SCRIPT_COMPONENT = Container({

--- a/src/open_samus_returns_rando/specific_patches/cosmetic_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/cosmetic_patches.py
@@ -1,4 +1,5 @@
 from mercury_engine_data_structures.formats import Bmdefs, Bmses, Bmtun
+
 from open_samus_returns_rando.constants import ALL_SCENARIOS
 from open_samus_returns_rando.misc_patches import lua_util
 from open_samus_returns_rando.patcher_editor import PatcherEditor

--- a/src/open_samus_returns_rando/specific_patches/door_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/door_patches.py
@@ -6,6 +6,7 @@ from enum import Enum
 from construct import Container, ListContainer  # type: ignore[import-untyped]
 from mercury_engine_data_structures.formats import Bmsad, Bmsld, Bmsmsd, Lua
 from mercury_engine_data_structures.formats.bmsmsd import IconPriority, TileBorders
+
 from open_samus_returns_rando.files import files_path
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 

--- a/src/open_samus_returns_rando/specific_patches/game_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/game_patches.py
@@ -1,5 +1,6 @@
 from construct import Container  # type: ignore[import-untyped]
 from mercury_engine_data_structures.formats import Bmsad, Bmsbk
+
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 

--- a/src/open_samus_returns_rando/specific_patches/heat_room_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/heat_room_patches.py
@@ -2,6 +2,7 @@ import copy
 import typing
 
 from construct import Container, ListContainer  # type: ignore[import-untyped]
+
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 

--- a/src/open_samus_returns_rando/specific_patches/metroid_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/metroid_patches.py
@@ -2,6 +2,7 @@ import typing
 
 from construct import ListContainer  # type: ignore[import-untyped]
 from mercury_engine_data_structures.formats import Bmsad
+
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 

--- a/src/open_samus_returns_rando/specific_patches/static_fixes.py
+++ b/src/open_samus_returns_rando/specific_patches/static_fixes.py
@@ -3,6 +3,7 @@ import typing
 
 from construct import Container, ListContainer  # type: ignore[import-untyped]
 from mercury_engine_data_structures.formats import Bmsad, Bmsbk, Bmscc, Bmssd, Bmtun
+
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 MULTI_ROOM_GAMMAS = [

--- a/src/open_samus_returns_rando/specific_patches/tunable_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/tunable_patches.py
@@ -1,4 +1,5 @@
 from mercury_engine_data_structures.formats.bmtun import Bmtun
+
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 


### PR DESCRIPTION
My vscode uses the bundled ruff and they changed how imports are sorted. Very annoying to see all this errors, so I see if this PR works with a manual version update