### PR TITLE
Improve crumble block removal patches

### DIFF
--- a/src/open_samus_returns_rando/specific_patches/game_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/game_patches.py
@@ -2,6 +2,7 @@ import typing
 
 from construct import Container  # type: ignore[import-untyped]
 from mercury_engine_data_structures.formats import Bmsad, Bmsbk, Bmssd
+
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 


### PR DESCRIPTION
Completely removes the blocks if the configurations are set, instead of having them never respawn.

Surface
![image](https://github.com/user-attachments/assets/39a5b4a9-2eea-4eea-a0a4-03f43fc093ee)

Area 1
![image](https://github.com/user-attachments/assets/5d903616-099c-4472-8573-f80f128a84a9)

Fixes #427 