### PR TITLE
Automatically update the hud when starting Diggernaut fight

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s070_area7.lua
+++ b/src/open_samus_returns_rando/files/levels/s070_area7.lua
@@ -866,6 +866,7 @@ function s070_area7.LaunchManicMinerBotIntroCutscene()
     Game.SetItemAmount(Game.GetPlayerName(), "ITEM_WEAPON_POWER_BOMB_MAX", 0)
     Game.SetItemAmount(Game.GetPlayerName(), "ITEM_WEAPON_POWER_BOMB_CURRENT", 0)
     Game.SetItemAmount(Game.GetPlayerName(), "ITEM_POWER_BOMB_TANKS", PreFightPBMax)
+    hud.UpdatePlayerInfo(true)
   end
 end
 function s070_area7.OnStartManicMinerBotIntroCutscene()


### PR DESCRIPTION
PBs are now seamlessly removed from the HUD when starting the fight instead of having to manually update it with R.