### PR TITLE
Allow access to Diggernaut in reverse if final boss

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s070_area7.lua
+++ b/src/open_samus_returns_rando/files/levels/s070_area7.lua
@@ -163,6 +163,13 @@ function s070_area7.OnExitHazardous_001()
   PoisonZone.OnExit()
   Game.SetSubAreaCurrentSetup("collision_camera_Hazard_End_A", "Default", false)
 end
+function s070_area7.OnEnter_Diggernaut_Access()
+  if Init.sFinalBoss == "Diggernaut" and not Blackboard.GetProp("GAME", "OBJECTIVE_COMPLETE") then
+    local startpoint = "Diggernaut"
+    GUI.LaunchMessage("Not enough Metroid DNA!\nCollect more DNA to fight Diggernaut!", "RandomizerPowerup.Dummy", "")
+    Game.AddSF(0, "Scenario.FinalBossReload", "s", startpoint)
+  end
+end
 function s070_area7.OnZeta_001_Intro_Generated(_ARG_0_, _ARG_1_)
   s070_area7.OnZeta_001_Generated(_ARG_0_, _ARG_1_)
 end

--- a/src/open_samus_returns_rando/files/levels/s070_area7.lua
+++ b/src/open_samus_returns_rando/files/levels/s070_area7.lua
@@ -164,10 +164,14 @@ function s070_area7.OnExitHazardous_001()
   Game.SetSubAreaCurrentSetup("collision_camera_Hazard_End_A", "Default", false)
 end
 function s070_area7.OnEnter_Diggernaut_Access()
-  if Init.sFinalBoss == "Diggernaut" and not Blackboard.GetProp("GAME", "OBJECTIVE_COMPLETE") then
-    local startpoint = "Diggernaut"
-    GUI.LaunchMessage("Not enough Metroid DNA!\nCollect more DNA to fight Diggernaut!", "RandomizerPowerup.Dummy", "")
-    Game.AddSF(0, "Scenario.FinalBossReload", "s", startpoint)
+  if Init.sFinalBoss == "Diggernaut" then
+    if not Blackboard.GetProp("GAME", "OBJECTIVE_COMPLETE") then
+      local startpoint = "Diggernaut"
+      GUI.LaunchMessage("Not enough Metroid DNA!\nCollect more DNA to fight Diggernaut!", "RandomizerPowerup.Dummy", "")
+      Game.AddSF(0, "Scenario.FinalBossReload", "s", startpoint)
+    else
+      Game.GetPlayer().vPos = V3D(-18500, -7600, 0)
+    end
   end
 end
 function s070_area7.OnZeta_001_Intro_Generated(_ARG_0_, _ARG_1_)
@@ -823,7 +827,7 @@ function s070_area7.OnSubAreaChange(_ARG_0_, _ARG_1_, _ARG_2_, _ARG_3_, _ARG_4_)
     if not Scenario.ReadFromBlackboard("ManicMinerBotStealOrbPlayed", false) then
       s070_area7.LaunchManicMinerBotStealOrb()
     end
-  elseif _ARG_0_ == "collision_camera_034" and _ARG_2_ == "collision_camera_043" then
+  elseif _ARG_2_ == "collision_camera_043" then
     if Init.sFinalBoss == "Diggernaut" and not Blackboard.GetProp("GAME", "OBJECTIVE_COMPLETE") then
       Game.AddSF(0, "Scenario.ShowFinalBossMessage", "")
     elseif not Scenario.ReadFromBlackboard("ManicMinerBotIntroCutscenePlayed", false) then
@@ -935,6 +939,9 @@ function s070_area7.OnEndManicMinerBotDeathCutscene()
 end
 function s070_area7.OnEnter_SetCheckpoint_001_ManicMiner()
   Game.SetBossCheckPointNames("ST_SG_ManicMiner_Checkpoint", "ST_SG_ManicMiner_Checkpoint", "SG_ManicMinerBot", "", "")
+end
+function s070_area7.OnEnter_SetCheckpoint_002_ManicMiner()
+  Game.SetBossCheckPointNames("ST_SG_Diggernaut_Checkpoint", "ST_SG_Diggernaut_Checkpoint", "SG_ManicMinerBot", "", "")
 end
 function s070_area7.OnManicMinerBotGenerated(_ARG_0_, _ARG_1_)
   if _ARG_1_ ~= nil then

--- a/src/open_samus_returns_rando/misc_patches/final_boss.py
+++ b/src/open_samus_returns_rando/misc_patches/final_boss.py
@@ -15,6 +15,9 @@ class NewTrigger(typing.NamedTuple):
 
 
 new_triggers = [
+    NewTrigger(
+        "s070_area7", "TG_Diggernaut_Access", [-20900.0, -7700.0, 0.0], [50, 700, 300], ["collision_camera_045"]
+    ),
     NewTrigger("s100_area10", "TG_Queen_Access", [1000.0, 12050.0, 0.0], [500, 300, 300], ["collision_camera_019"]),
     NewTrigger("s110_surfaceb", "TG_Ridley_Access", [-22800.0, 4400.0, 0.0], [150, 800, 800], ["collision_camera_017"]),
 ]

--- a/src/open_samus_returns_rando/misc_patches/final_boss.py
+++ b/src/open_samus_returns_rando/misc_patches/final_boss.py
@@ -79,6 +79,8 @@ def patch_final_boss(editor: PatcherEditor, configuration: dict) -> None:
             if not game_patches["remove_elevator_grapple_blocks"]:
                 scenario = editor.get_scenario("s070_area7")
                 scenario.raw.actors[9]["LE_GrappleMov_001"]["position"][0] = -15250.0
+            # Remove the breakable Grapple block to allow access to Diggernaut backwards
+            editor.remove_entity({"scenario": "s070_area7", "layer": 9, "actor": "LE_GrappleDest_012"})
         elif final_boss == "Queen":
             # Remove the Queen wall regardless if the config is set
             if not game_patches["reverse_area8"]:

--- a/src/open_samus_returns_rando/misc_patches/final_boss.py
+++ b/src/open_samus_returns_rando/misc_patches/final_boss.py
@@ -18,6 +18,13 @@ new_triggers = [
     NewTrigger(
         "s070_area7", "TG_Diggernaut_Access", [-20900.0, -7700.0, 0.0], [50, 700, 300], ["collision_camera_045"]
     ),
+    NewTrigger(
+        "s070_area7",
+        "TG_SetCheckpoint_002_ManicMiner",
+        [-21450.0, -7600.0, 0.0],
+        [50, 700, 300],
+        ["collision_camera_045"],
+    ),
     NewTrigger("s100_area10", "TG_Queen_Access", [1000.0, 12050.0, 0.0], [500, 300, 300], ["collision_camera_019"]),
     NewTrigger("s110_surfaceb", "TG_Ridley_Access", [-22800.0, 4400.0, 0.0], [150, 800, 800], ["collision_camera_017"]),
 ]

--- a/src/open_samus_returns_rando/misc_patches/spawn_points.py
+++ b/src/open_samus_returns_rando/misc_patches/spawn_points.py
@@ -19,6 +19,9 @@ new_spawnpoints = [
         "s050_area5", "ST_Diggernaut_Chase_Respawn", [-2100.0, -4800.0, 0.0], 90, ["collision_camera_AfterChase_001"]
     ),
     NewSpawnPoint(
+        "s070_area7", "ST_SG_Diggernaut", [-21450.0, -7600.0, 0.0], 90, ["collision_camera_045"]
+    ),
+    NewSpawnPoint(
         "s110_surfaceb", "ST_SurfaceB_Connector", [-23179.0, 4500.0, 0.0], -90, ["collision_camera_017"]
     ),
 ]

--- a/src/open_samus_returns_rando/misc_patches/spawn_points.py
+++ b/src/open_samus_returns_rando/misc_patches/spawn_points.py
@@ -19,7 +19,7 @@ new_spawnpoints = [
         "s050_area5", "ST_Diggernaut_Chase_Respawn", [-2100.0, -4800.0, 0.0], 90, ["collision_camera_AfterChase_001"]
     ),
     NewSpawnPoint(
-        "s070_area7", "ST_SG_Diggernaut", [-21450.0, -7600.0, 0.0], 90, ["collision_camera_045"]
+        "s070_area7", "ST_SG_Diggernaut_Checkpoint", [-21450.0, -7600.0, 0.0], 90, ["collision_camera_045"]
     ),
     NewSpawnPoint(
         "s110_surfaceb", "ST_SurfaceB_Connector", [-23179.0, 4500.0, 0.0], -90, ["collision_camera_017"]


### PR DESCRIPTION
Main purpose of this is to keep the item behind Diggernaut accessible regardless if it's the final boss or not.

Removes the smaller Grapple block by the elevator
![image](https://github.com/user-attachments/assets/07b6da3c-4840-471a-8fee-1048a9734031)

Adds a DNA check and checkpoint to the left door to the arena
![image](https://github.com/user-attachments/assets/aa43f2e2-ec61-44d8-bb19-d20d4cdce8ce)
