### PR TITLE
Always enable Ridley trigger regardless if final boss

### DIFF
--- a/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
+++ b/src/open_samus_returns_rando/files/levels/s110_surfaceb.lua
@@ -61,8 +61,15 @@ function s110_surfaceb.ElevatorSetTarget(_ARG_0_)
 end
 function s110_surfaceb.InitFromBlackboard()
   s110_surfaceb.SetLowModelsVisibility(false)
-  if Game.GetItemAmount(Game.GetPlayerName(), "ITEM_ADN") > 0 and Game.GetItemAmount(Game.GetPlayerName(), "ITEM_BABY_HATCHLING") < 1 then
-    Game.PlayMusicStream(0, "streams/music/t_m2_surface_arr1.wav", -1, -1, -1, 2, 2, 1)
+  if not Blackboard.GetProp("GAME", "OBJECTIVE_COMPLETE") then
+    if Init.sFinalBoss == "Ridley" then
+      Game.DisableEntity("TG_Ridley_Access")
+    end
+    if Game.GetItemAmount(Game.GetPlayerName(), "ITEM_BABY_HATCHLING") < 1 then
+      Game.PlayMusicStream(0, "streams/music/t_m2_surface_arr1.wav", -1, -1, -1, 2, 2, 1)
+    end
+  else
+    Game.EnableTrigger("TG_Ridley_Access")
   end
   if Blackboard.GetProp("DEFEATED_ENEMIES", "Ridley") and Game.GetEntity("TG_Ridley_Access") ~= nil then
     Game.DeleteEntity("TG_Ridley_Access")
@@ -106,7 +113,13 @@ function s110_surfaceb.LoadSurface()
   Scenario.LoadNewScenario("s000_surface", "ST_Surface_Connector")
 end
 function s110_surfaceb.OnEnter_Ridley_Access()
-  GUI.LaunchMessage("Proteus Ridley can be fought at any time.\nAre you prepared to fight?", "s110_surfaceb.OnReloaded", "s110_surfaceb.LoadSurface")
+  local message = ""
+  if Init.sFinalBoss == "Ridley" then
+    message = "The path to Proteus Ridley is now open."
+  else
+    message = "Proteus Ridley can be fought at any time."
+  end
+  GUI.LaunchMessage(message .. "\nAre you prepared to fight?", "s110_surfaceb.OnReloaded", "s110_surfaceb.LoadSurface")
 end
 function s110_surfaceb.OnRidleyStartPoint()
   Game.HUDIdleScreenLeave()

--- a/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
+++ b/src/open_samus_returns_rando/files/templates/randomizerpowerup.lua
@@ -242,6 +242,7 @@ function RandomizerPowerup.ObjectiveComplete()
             GUI.LaunchMessage(message, "RandomizerPowerup.Dummy", "")
             if Scenario.CurrentScenarioID == "s110_surfaceb" and boss == "Ridley" then
                 Game.PlayMusicStream(0, "streams/music/k_crateria99.wav", -1, -1, -1, 2, 2, 1)
+                Game.EnableTrigger("TG_Ridley_Access")
             end
         elseif baby == 0 then
             if boss == "Ridley" then

--- a/src/open_samus_returns_rando/misc_patches/final_boss.py
+++ b/src/open_samus_returns_rando/misc_patches/final_boss.py
@@ -6,7 +6,7 @@ from mercury_engine_data_structures.formats import Bmsad, Bmtun
 from open_samus_returns_rando.patcher_editor import PatcherEditor
 
 
-class NewTrigger(typing.NamedTuple):
+class BossTrigger(typing.NamedTuple):
     scenario: str
     name: str
     position: list[float]
@@ -14,48 +14,55 @@ class NewTrigger(typing.NamedTuple):
     entity_groups: list[str]
 
 
-new_triggers = [
-    NewTrigger(
+boss_triggers = [
+    BossTrigger(
         "s070_area7", "TG_Diggernaut_Access", [-20900.0, -7700.0, 0.0], [50, 700, 300], ["collision_camera_045"]
     ),
-    NewTrigger(
+    BossTrigger(
         "s070_area7",
         "TG_SetCheckpoint_002_ManicMiner",
         [-21450.0, -7600.0, 0.0],
         [50, 700, 300],
         ["collision_camera_045"],
     ),
-    NewTrigger("s100_area10", "TG_Queen_Access", [1000.0, 12050.0, 0.0], [500, 300, 300], ["collision_camera_019"]),
-    NewTrigger("s110_surfaceb", "TG_Ridley_Access", [-22800.0, 4400.0, 0.0], [150, 800, 800], ["collision_camera_017"]),
+    BossTrigger("s100_area10", "TG_Queen_Access", [1000.0, 12050.0, 0.0], [500, 300, 300], ["collision_camera_019"]),
 ]
 
+ridley_trigger = BossTrigger(
+    "s110_surfaceb", "TG_Ridley_Access", [-22800.0, 4400.0, 0.0], [150, 800, 800], ["collision_camera_017"]
+)
 
-def add_boss_triggers(editor: PatcherEditor, new_trigger: NewTrigger) -> None:
+
+def add_boss_triggers(editor: PatcherEditor, boss_trigger: BossTrigger) -> None:
     template_tg = editor.get_scenario("s110_surfaceb").raw.actors[0]["TG_Activation_Teleport_00b_01"]
 
-    scenario_name = new_trigger.scenario
+    scenario_name = boss_trigger.scenario
     scenario_file = editor.get_scenario(scenario_name)
 
-    editor.copy_actor(scenario_name, new_trigger.position, template_tg, new_trigger.name, 0)
+    editor.copy_actor(scenario_name, boss_trigger.position, template_tg, boss_trigger.name, 0)
 
-    arguments = scenario_file.raw.actors[0][new_trigger.name]["components"][0]["arguments"]
-    arguments[3]["value"] = "CurrentScenario.OnEnter_" + new_trigger.name[3:]
+    arguments = scenario_file.raw.actors[0][boss_trigger.name]["components"][0]["arguments"]
+    arguments[3]["value"] = "CurrentScenario.OnEnter_" + boss_trigger.name[3:]
     # Set the size of the trigger to fill the opening
-    arguments[16]["value"] = new_trigger.size[0]
-    arguments[17]["value"] = new_trigger.size[1]
-    arguments[18]["value"] = new_trigger.size[2]
+    arguments[16]["value"] = boss_trigger.size[0]
+    arguments[17]["value"] = boss_trigger.size[1]
+    arguments[18]["value"] = boss_trigger.size[2]
 
-    for entity_group in new_trigger.entity_groups:
-        scenario_file.add_actor_to_entity_groups(entity_group, new_trigger.name, True)
+    for entity_group in boss_trigger.entity_groups:
+        scenario_file.add_actor_to_entity_groups(entity_group, boss_trigger.name, True)
 
 
 def patch_final_boss(editor: PatcherEditor, configuration: dict) -> None:
     final_boss = configuration["objective"]["final_boss"]
     game_patches = configuration["game_patches"]
+
+    # Always add the trigger for Ridley
+    add_boss_triggers(editor, ridley_trigger)
+
     if final_boss != "Ridley":
-        # Add new boss triggers
-        for new_trigger in new_triggers:
-            add_boss_triggers(editor, new_trigger)
+        # Add the trigger that corresponds with the final boss
+        for boss_trigger in boss_triggers:
+            add_boss_triggers(editor, boss_trigger)
         if final_boss == "Arachnus":
             # Buff Arachnus so the fight isn't trivial
             arachnus = editor.get_file("actors/characters/arachnus/charclasses/arachnus.bmsad", Bmsad)


### PR DESCRIPTION
The trigger that was added if Ridley was not the final boss is now always added.

- If the final boss is Ridley and you have all DNA, then the message appears when trying to enter the landing site
- If you don't have all DNA, you can go on through freely
- If Ridley is not the final boss, the message appears like it did before

Fixes #499 