### PR TITLE
Rebalance beams

### DIFF
--- a/src/open_samus_returns_rando/files/custom/randoapi.lua
+++ b/src/open_samus_returns_rando/files/custom/randoapi.lua
@@ -32,6 +32,6 @@ function RandoApi.CheckBeams()
     local hasSpazer = RandomizerPowerup.GetItemAmount("ITEM_WEAPON_SPAZER_BEAM") > 0
     local hasPlasma = RandomizerPowerup.GetItemAmount("ITEM_WEAPON_PLASMA_BEAM") > 0
 
-    -- Damage values are Solo Spazer, Solo Plasma, Plasma + Wave, and Plasma + Spazer, respctively
-    RandoApi.ChangeBeams(hasWave, hasSpazer, hasPlasma, 40, 75, 90, 82.5)
+    -- Damage values are Solo Spazer, Solo Plasma, Plasma + Wave, and Plasma + Spazer, respectively
+    RandoApi.ChangeBeams(hasWave, hasSpazer, hasPlasma, 40, 85, 95, 90)
 end


### PR DESCRIPTION
- Solo Plasma increased to 85 from 75
  - It felt too weak on its own for such a powerful beam so the increase feels necessary
- Plasma + Spazer increased to 90 from 82.5 to account for the Plasma bump
  - Spazer shot increases to 270 from 247.5, which still puts it 30 damage lower than vanilla, which still incentivizes Wave
- Plasma + Wave increased to 95 from 90 to account for the previous bump
  - This may seem OP, but vanilla is 100 for a single shot and 300 for the Spazer shot, so this still incentivizes Spazer