### PR TITLE
Fix configuration default for `final_boss_hint`

### DIFF
--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -268,7 +268,7 @@ class LuaEditor:
         # Handle older versions of the patcher
         if "baby_metroid_hint" in configuration or "final_boss_hint" in configuration:
             final_boss_hint = lua_util.wrap_string(
-                configuration.get("baby_metroid_hint", configuration["final_boss_hint"])
+                configuration.get("baby_metroid_hint", "final_boss_hint")
             )
 
         if "required_dna" in objective:

--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -263,13 +263,12 @@ class LuaEditor:
         if "layout_uuid" in configuration:
             layout_uuid = lua_util.wrap_string(configuration["layout_uuid"])
 
-
-        final_boss_hint = lua_util.wrap_string("No hint for the final boss was provided!")
         # Handle older versions of the patcher
-        if "baby_metroid_hint" in configuration or "final_boss_hint" in configuration:
-            final_boss_hint = lua_util.wrap_string(
-                configuration.get("baby_metroid_hint", "final_boss_hint")
+        final_boss_hint = lua_util.wrap_string(
+            configuration.get(
+                "baby_metroid_hint", configuration.get("final_boss_hint", "No hint for the final boss was provided!")
             )
+        )
 
         if "required_dna" in objective:
             required_dna = objective["required_dna"]


### PR DESCRIPTION
~Now properly gets the default value if not present. Before it was saying `configuration[configuration["final_boss_hint"]]`~

Now ensures that a message is provided regardless,