### PR TITLE
Better implementation of Music Shuffle

### DIFF
--- a/src/open_samus_returns_rando/specific_patches/cosmetic_patches.py
+++ b/src/open_samus_returns_rando/specific_patches/cosmetic_patches.py
@@ -43,14 +43,23 @@ def music_shuffle(editor: PatcherEditor, configuration: dict) -> None:
     if len(configuration["music_shuffle_dict"]) == 0:
         return
 
-    temp_dict: dict = {}
-    for f in list(editor.get_asset_names_in_folder("sounds/streams/music/")):
-        temp_dict[f] = editor.get_raw_asset(f)
+    bmdefs = editor.get_file("system/snd/scenariomusicdefs.bmdefs", Bmdefs)
+    sounds = bmdefs.raw["sounds"]
 
+    # Create a dictionary of all sounds using the volumes as the values
+    sound_dict: dict = {}
+    for sound in sounds:
+        sound_name = sound["file_path"][14:].split(".")[0]
+        sound_dict[sound_name] = sound["volume"]
+
+    # Assign the new sounds with their respective volumes
     for original, new in configuration["music_shuffle_dict"].items():
-        original_track = f"sounds/streams/music/{original}.bcwav"
-        new_track = temp_dict[f"sounds/streams/music/{new}.bcwav"]
-        editor.replace_asset(original_track, new_track)
+        for sound in sounds:
+            # Only change the sound if it matches to prevent changing it back when iterating
+            if original in sound["file_path"] and sound["sound_name"] in original:
+                sound["file_path"] = f"streams/music/{new}.wav"
+                sound["volume"] = sound_dict.get(new)
+                break
 
 
 def volume_patches(editor: PatcherEditor, configuration: dict) -> None:


### PR DESCRIPTION
Music Shuffle now properly modifies the bmdefs file directly instead of lazily making copies of the sound files and renaming them. This saves a whopping 164-174 MB of storage, which will greatly improve export times to 3DS if enabled! This has the added benefit of keeping the correct volume for each track instead of just inheriting the old one, which made some sounds too loud or too quiet.

Fixes #539 