### PR TITLE
Add an "item" as a check for completing the game (for RDV)

### DIFF
--- a/src/open_samus_returns_rando/files/custom/scenario.lua
+++ b/src/open_samus_returns_rando/files/custom/scenario.lua
@@ -223,6 +223,7 @@ function Scenario.FinalBossReload(startpoint)
 end
 
 function Scenario.LaunchCredits()
+  RandomizerPowerup.SetItemAmount("ITEM_RANDO_GAME_COMPLETE", 1)
   Game.ShowEndGameCredits(true)
 end
 

--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -803,7 +803,8 @@
                 "ITEM_RESERVE_TANK_LIFE",
                 "ITEM_RESERVE_TANK_MISSILE",
                 "ITEM_RESERVE_TANK_SPECIAL_ENERGY",
-                "ITEM_WEAPON_ICE_MISSILE"
+                "ITEM_WEAPON_ICE_MISSILE",
+                "ITEM_RANDO_GAME_COMPLETE"
             ]
         },
         "item": {

--- a/src/open_samus_returns_rando/files/schema.json
+++ b/src/open_samus_returns_rando/files/schema.json
@@ -803,8 +803,7 @@
                 "ITEM_RESERVE_TANK_LIFE",
                 "ITEM_RESERVE_TANK_MISSILE",
                 "ITEM_RESERVE_TANK_SPECIAL_ENERGY",
-                "ITEM_WEAPON_ICE_MISSILE",
-                "ITEM_RANDO_GAME_COMPLETE"
+                "ITEM_WEAPON_ICE_MISSILE"
             ]
         },
         "item": {


### PR DESCRIPTION
Relevant for https://github.com/randovania/randovania/pull/8502

I want to say this is all that is needed to make this work. I'm not entirely sure if I need to include this in the schema like I did. Also, I didn't create a new item in the traditional way like the other custom items, but it shouldn't be necessary since you never really collect it. It'd be nicer if RDV could just read the blackboard somehow but this will do for now.