### PR TITLE
Save a lua variable to indicate we beat the game

### DIFF
--- a/src/open_samus_returns_rando/files/custom/scenario.lua
+++ b/src/open_samus_returns_rando/files/custom/scenario.lua
@@ -223,6 +223,8 @@ function Scenario.FinalBossReload(startpoint)
 end
 
 function Scenario.LaunchCredits()
+  Init.bBeatenSinceLastReboot = true
+  RL.UpdateRDVClient(false)
   Game.ShowEndGameCredits(true)
 end
 

--- a/src/open_samus_returns_rando/files/templates/custom_init.lua
+++ b/src/open_samus_returns_rando/files/templates/custom_init.lua
@@ -1,7 +1,8 @@
 Game.ImportLibrary("system/scripts/init_original.lua")
 
 RL = RL or { 
-  -- defined by remote connector
+  -- defined by msr-remote-connector
+  -- somewhere around here: https://github.com/randovania/msr-remote-connector/blob/main/source/lua_hook.cpp#L19
   Init = function() end,
   Update = function() end,
   SendLog = function(message) end,
@@ -36,6 +37,7 @@ Init.sFinalBossHint = TEMPLATE("final_boss_hint")
 Init.bTanksRefillAmmo = TEMPLATE("tanks_refill_ammo")
 Init.iRequiredDNA = TEMPLATE("required_dna")
 Init.sFinalBoss = TEMPLATE("final_boss")
+Init.bBeatenSinceLastReboot = false
 
 local orig_log = Game.LogWarn
 if TEMPLATE("enable_remote_lua") then


### PR DESCRIPTION
Same goal as #564 but instead of using an item to save it, we use a lua variable that saves the value until the game was last restarted.

I originally also wanted to save it in the save file similar to how it was mentioned here: https://github.com/randovania/msr-remote-connector/pull/4#issuecomment-3394233528

However, I couldn't find a good way to actually save it. Using a blackboard property (or anything similar) needs saving the actual game, which when every time i tried it, the game would just reset back to MAINMENU when loading the save file after it was beaten. (If it matters, I tried saving via `Game.SaveGame("savedata", "", Blackboard.GetProp(playerSection, "StartPoint"), true)`)

There *is* another way to save progress in a save file, but that will be permanent until the save file is *deleted*, meaning it will be persistent across the "new game" option. Which obviously isn't desirable here.
