### PR TITLE
Fix BMSAD no longer uses actor_def_id of ScriptClass

### DIFF
--- a/src/open_samus_returns_rando/lua_editor.py
+++ b/src/open_samus_returns_rando/lua_editor.py
@@ -79,9 +79,6 @@ class ScriptClass:
         parent_lower = self.lua_parent.lower()
         return f"actors/items/{parent_lower}/scripts/{parent_lower}.lc"
 
-    def get_bmsad_path(self) -> str:
-        return f"actors/items/{self.actor_def_name}/charclasses/{self.actor_def_name}.bmsad"
-
     def ensure_files(self, editor: PatcherEditor) -> None:
         # ensure file itself
         lua_file_name = self.get_lua_file_name()

--- a/src/open_samus_returns_rando/pickups/pickup.py
+++ b/src/open_samus_returns_rando/pickups/pickup.py
@@ -28,6 +28,10 @@ def _read_template_powerup() -> dict:
         return json.load(f)
 
 
+def _bmsad_path_for(actordef_id: str) -> str:
+    return f"actors/items/{actordef_id}/charclasses/{actordef_id}.bmsad"
+
+
 class PickupType(Enum):
     ACTOR = "actor"
     METROID = "metroid"
@@ -71,7 +75,7 @@ class ActorPickup(BasePickup):
         # Update given item
         new_template, script_class = self.patch_item_pickup(new_template)
 
-        new_path = script_class.get_bmsad_path()
+        new_path = _bmsad_path_for(actordef_id)
         editor.add_new_asset(new_path, Bmsad(new_template, editor.target_game), in_pkgs=pkgs_for_level)  # type: ignore
         return script_class
 
@@ -170,7 +174,7 @@ class ActorPickup(BasePickup):
         else:
             actordef_id = cached_bmsad[0]
             script_class = cached_bmsad[1]
-            bmsad_path = script_class.get_bmsad_path()
+            bmsad_path = _bmsad_path_for(actordef_id)
             editor.ensure_present_in_scenario(scenario_name, bmsad_path)
 
         actor.type = actordef_id
@@ -184,7 +188,7 @@ class ActorPickup(BasePickup):
             mirrored_actor = next((layer[actor_name] for layer in surface_b.raw.actors if actor_name in layer), None)
             assert mirrored_actor is not None
             mirrored_actor.type = actordef_id
-            path = script_class.get_bmsad_path()
+            path = _bmsad_path_for(actordef_id)
             editor.ensure_present_in_scenario(surfaceb_name, path)
             pkgs_for_level.update(set(editor.find_pkgs(path_for_level(surfaceb_name) + ".bmsld")))
 


### PR DESCRIPTION
See https://discord.com/channels/914291389293027329/1048258924790419548/1500428782706622517

If my writing is too strange, here is a llm generated explanation of the bug:


When patching pickups, two pickup types exist: `metroid` and `actor`. Identical pickups (same `item_id`, `quantity`, `caption`) reuse the same `ScriptClass` via [`LuaEditor._item_classes`](src/open_samus_returns_rando/lua_editor.py#L140-L142) — the lua content is identical, so sharing avoids duplicate lua files.

The bug: a shared `ScriptClass` carries the `actor_def_name` of whichever caller created it **first**, and `ScriptClass.get_bmsad_path()` derives its path from that name. This produces a mismatch when a `MetroidPickup` precedes an `ActorPickup` for the same logical pickup:

1. `MetroidPickup` (id=0) calls `create_script_class(..., "metroid_0")` → ScriptClass cached with `actor_def_name = "metroid_0"`. No bmsad is created (metroid only needs the lua file).
2. Later `ActorPickup` (id=5) with the same item_id/quantity/caption is **not** in [`ActorPickup._bmsad_dict`](src/open_samus_returns_rando/pickups/pickup.py#L51) → enters [`add_new_bmsad`](src/open_samus_returns_rando/pickups/pickup.py#L62) with `actordef_id = "randomizerpowerup5"`.
3. Inside, [`patch_item_pickup`](src/open_samus_returns_rando/pickups/pickup.py#L53-L60) calls `create_script_class` again, which returns the **cached** `metroid_0` ScriptClass (the new `actordef_id` is silently ignored).
4. [`script_class.get_bmsad_path()`](src/open_samus_returns_rando/pickups/pickup.py#L74) returns `actors/items/metroid_0/charclasses/metroid_0.bmsad` — but the bmsad's internal `name` is `randomizerpowerup5`, and the scenario actor gets `actor.type = "randomizerpowerup5"` (line 176). The engine looks up `actors/items/randomizerpowerup5/charclasses/randomizerpowerup5.bmsad`, which was never written.

The same flaw affects the cached path in [`ActorPickup.patch`](src/open_samus_returns_rando/pickups/pickup.py#L171-L188) (lines 173 and 187), which also call `script_class.get_bmsad_path()` to register scenario dependencies — they will register the wrong path for any actor pickup whose ScriptClass was originally minted by a metroid.

The current code "silently assumes" (per the user's framing) that a fresh `_bmsad_dict` miss implies a fresh `ScriptClass`. That assumption holds only when no metroid pickup minted the ScriptClass first.